### PR TITLE
fix CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
     branches:
-      - master
+      - main
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The CI workflow runs only when pushes are made/PRs are opened to `master`. Since MTKStdLib has a `main` branch and not a `master` branch, this would mean that the CI never runs. Fix the CI script accordingly to have it run as expected.