### PR TITLE
Revert "CompatHelper: bump compat for ModelingToolkit to 8, (keep existing compat)"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 IfElse = "0.1"
-ModelingToolkit = "5.26, 6, 7, 8"
+ModelingToolkit = "5.26, 6, 7"
 OffsetArrays = "1"
 OrdinaryDiffEq = "5.56, 6"
 Symbolics = "0.1, 1, 2, 3, 4"


### PR DESCRIPTION
Reverts SciML/ModelingToolkitStandardLibrary.jl#23