### PR TITLE
Remove some arbitrary defaults

### DIFF
--- a/src/Blocks/math.jl
+++ b/src/Blocks/math.jl
@@ -1,5 +1,5 @@
 """
-    Gain(k=1; name)
+    Gain(k; name)
 
 Output the product of a gain value with the input signal.
 
@@ -10,7 +10,7 @@ Output the product of a gain value with the input signal.
 - `input`
 - `output`
 """
-function Gain(k=1; name)
+function Gain(k; name)
     @named siso = SISO()
     @unpack u, y = siso
     pars = @parameters k=k

--- a/src/Electrical/Analog/ideal_components.jl
+++ b/src/Electrical/Analog/ideal_components.jl
@@ -17,7 +17,7 @@ end
 
 """
 ```julia
-function Resistor(; name, R = 1.0)
+function Resistor(; name, R)
 ```
 
 Creates an ideal Resistor following Ohm's Law.
@@ -36,7 +36,7 @@ Creates an ideal Resistor following Ohm's Law.
 - `R`: [`Ω`]
   Resistance
 """
-function Resistor(;name, R=1.0)
+function Resistor(;name, R)
     @named oneport = OnePort()
     @unpack v, i = oneport
     pars = @parameters R=R
@@ -48,7 +48,7 @@ end
 
 """
 ```julia
-function Capacitor(; name, C = 1.0)
+function Capacitor(; name, C)
 ```
 
 Creates an ideal Capacitor.
@@ -69,7 +69,7 @@ Creates an ideal Capacitor.
 - `v_start`: [`V`]
   Initial voltage of capacitor
 """
-function Capacitor(;name, C=1.0, v_start=0.0) 
+function Capacitor(;name, C, v_start=0.0) 
     @named oneport = OnePort(;v_start=v_start)
     @unpack v, i = oneport
     pars = @parameters C=C
@@ -81,7 +81,7 @@ end
 
 """
 ```julia
-function Inductor(; name, L = 1.0)
+function Inductor(; name, L)
 ```
 
 Creates an ideal Inductor.
@@ -102,7 +102,7 @@ Creates an ideal Inductor.
 - `i_start`: [`A`]
   Initial current through inductor
 """
-function Inductor(;name, L=1.0e-6, i_start=0.0)
+function Inductor(;name, L, i_start=0.0)
     @named oneport = OnePort(;i_start=i_start)
     @unpack v, i = oneport
     pars = @parameters L=L

--- a/src/Electrical/Analog/sources.jl
+++ b/src/Electrical/Analog/sources.jl
@@ -18,7 +18,7 @@ _xH(t, δ, tₒ) = (t-tₒ)*(1+((t-tₒ)/sqrt((t-tₒ)^2+δ^2)))/2
 
 """
 ```julia
-function ConstantVoltage(; name, V=1.0)
+function ConstantVoltage(; name, V)
 ```
 
 The source for an ideal constant voltage.
@@ -37,7 +37,7 @@ The source for an ideal constant voltage.
 - `V`: [`V`]
   The constant voltage across the terminals of this source
 """
-function ConstantVoltage(;name, V = 1.0)   
+function ConstantVoltage(;name, V)   
     @named oneport = OnePort()
     @unpack v, i = oneport
     pars = @parameters V=V

--- a/src/Mechanical/Rotational/components.jl
+++ b/src/Mechanical/Rotational/components.jl
@@ -14,7 +14,7 @@ function Fixed(;name, phi0=0.0)
 end
 
 """
-    Inertia(;name, J=1.0, phi_start=0.0, w_start=0.0, a_start=0.0)
+    Inertia(;name, J, phi_start=0.0, w_start=0.0, a_start=0.0)
 
 1D-rotational component with inertia.
 
@@ -29,7 +29,7 @@ end
 - `w`: [rad/s] Absolute angular velocity of component (= der(phi)) 
 - `a`: [rad/s²] Absolute angular acceleration of component (= der(w)) 
 """
-function Inertia(;name, J=1.0, phi_start=0.0, w_start=0.0, a_start=0.0)
+function Inertia(;name, J, phi_start=0.0, w_start=0.0, a_start=0.0)
     @named flange_a = Flange()
     @named flange_b = Flange()
     @parameters J=J
@@ -57,7 +57,7 @@ Linear 1D rotational spring
 - `c`: [N.m/rad] Spring constant
 - `phi_rel0`: Unstretched spring angle
 """
-function Spring(;name, c=1.0e5, phi_rel0=0.0)
+function Spring(;name, c, phi_rel0=0.0)
     @named partial_comp = PartialCompliant()
     @unpack phi_rel, tau = partial_comp
     pars = @parameters begin
@@ -69,14 +69,14 @@ function Spring(;name, c=1.0e5, phi_rel0=0.0)
 end
 
 """
-    Damper(;name, d=0.0) 
+    Damper(;name, d) 
 
 Linear 1D rotational damper
 
 # Parameters:
 - `d`: [N.m.s/rad] Damping constant
 """
-function Damper(;name, d=0.0) 
+function Damper(;name, d) 
     @named partial_comp = PartialCompliantWithRelativeStates()
     @unpack w_rel, tau = partial_comp
     pars = @parameters d=d 

--- a/src/Thermal/HeatTransfer/ideal_components.jl
+++ b/src/Thermal/HeatTransfer/ideal_components.jl
@@ -1,5 +1,5 @@
 """
-    HeatCapacitor(; name, C=1.0, T_start=293.15 + 20)    
+    HeatCapacitor(; name, C, T_start=293.15 + 20)    
 
 Lumped thermal element storing heat
 
@@ -11,7 +11,7 @@ Lumped thermal element storing heat
 - `T`: [K] Temperature of element
 - `der_T`: [K/s] Time derivative of temperature
 """
-function HeatCapacitor(; name, C=1.0, T_start=293.15 + 20)    
+function HeatCapacitor(; name, C, T_start=293.15 + 20)    
     @named port = HeatPort()
     @parameters C=C
     sts = @variables begin
@@ -29,14 +29,14 @@ function HeatCapacitor(; name, C=1.0, T_start=293.15 + 20)
 end
 
 """
-    ThermalConductor(;name, G=1.0) 
+    ThermalConductor(;name, G) 
 
 Lumped thermal element transporting heat without storing it.
 
 # Parameters:
 - `G`: [W/K] Constant thermal conductance of material
 """
-function ThermalConductor(;name, G=1.0)   
+function ThermalConductor(;name, G)   
     @named element1d = Element1D()
     @unpack Q_flow, dT = element1d
     pars = @parameters G=G
@@ -47,14 +47,14 @@ function ThermalConductor(;name, G=1.0)
 end
 
 """
-    ThermalResistor(; name, R=1.0) 
+    ThermalResistor(; name, R) 
 
 Lumped thermal element transporting heat without storing it.
 
 # Parameters:
 - `R`: [K/W] Constant thermal resistance of material
 """
-function ThermalResistor(; name, R=1.0)   
+function ThermalResistor(; name, R)   
     @named element1d = Element1D()
     @unpack Q_flow, dT = element1d
     pars = @parameters R=R
@@ -66,7 +66,7 @@ function ThermalResistor(; name, R=1.0)
 end
 
 """
-    ConvectiveConductor(; name, G=1.0)
+    ConvectiveConductor(; name, G)
 
 Lumped thermal element for heat convection.
 
@@ -77,7 +77,7 @@ Lumped thermal element for heat convection.
 - `dT`:  [K] Temperature difference across the component solid.T - fluid.T
 - `Q_flow`: [W] Heat flow rate from solid -> fluid
 """
-function ConvectiveConductor(; name, G=1.0)
+function ConvectiveConductor(; name, G)
     @named solid = HeatPort()
     @named fluid = HeatPort()
     @parameters G=G
@@ -92,7 +92,7 @@ function ConvectiveConductor(; name, G=1.0)
 end
 
 """
-    ConvectiveResistor(; name, R=1.0)
+    ConvectiveResistor(; name, R)
 
 Lumped thermal element for heat convection.
 
@@ -103,7 +103,7 @@ Lumped thermal element for heat convection.
 - `dT`:  [K] Temperature difference across the component solid.T - fluid.T
 - `Q_flow`: [W] Heat flow rate from solid -> fluid
 """
-function ConvectiveResistor(; name, R=1.0)
+function ConvectiveResistor(; name, R)
     @named solidport = HeatPort()
     @named fluidport = HeatPort()
     @parameters R=R
@@ -118,14 +118,14 @@ function ConvectiveResistor(; name, R=1.0)
 end
 
 """
-    BodyRadiation(; name, G=1.0)
+    BodyRadiation(; name, G)
 
 Lumped thermal element for radiation heat transfer.
 
 # Parameters:
 - `G`: [m^2] Net radiation conductance between two surfaces
 """
-function BodyRadiation(; name, G=1.0)
+function BodyRadiation(; name, G)
     sigma = 5.6703744191844294e-8 # Stefan-Boltzmann constant TODO: extract into physical constants module or use existing one
 
     @named element1d = Element1D()
@@ -142,13 +142,13 @@ end
 """
     ThermalCollector(; name, m=1)
 
-Collects m heat flows
+Collects `m` heat flows
 
 This is a model to collect the heat flows from `m` heatports to one single heatport.
 # Parameters:
 - `m`: Number of heat ports (e.g. m=2: `port_a1`, `port_a2`)
 """
-function ThermalCollector(; name, m=1)
+function ThermalCollector(; name, m::Integer=1)
     port_a = [HeatPort(name=Symbol(:port_a, i)) for i in 1:m]
     @named port_b = HeatPort()
     eqs = [

--- a/src/Thermal/HeatTransfer/sources.jl
+++ b/src/Thermal/HeatTransfer/sources.jl
@@ -27,7 +27,7 @@ function FixedHeatFlow(; name, Q_flow=1.0, T_ref=293.15, alpha=0.0)
 end
 
 """
-    FixedTemperature(; name, T=0.0)
+    FixedTemperature(; name, T)
 
 Fixed temperature boundary condition in kelvin.
 
@@ -36,7 +36,7 @@ This model defines a fixed temperature T at its port in kelvin, i.e., it defines
 # Parameters:
 - `T`: [K] Fixed temperature boundary condition
 """
-function FixedTemperature(; name, T=0.0)
+function FixedTemperature(; name, T)
     @named port = HeatPort()
     pars = @parameters T=T
     eqs = [


### PR DESCRIPTION
This PR removes the most arbitrary defaults I could find. The rational being that defaults are only useful if they apply to a vast majority of people. Values that are highly likely to be changed should not be associated with defaults since this can hide logical bugs in the model.

Some details

1. Remove defaults that lead to a component being a noop, e.g., gain=1
2. Component values arbitrarily set to 1, e.g., the capacitance of a capacitor.
3. I have *not* removed default amplitude 1 of periodic signals since it's common to change this with a subsequent gain block etc. 
4. Some defaults that are somewhat arbitrary are left, like `T_start=293.15 + 20` being *close* to a common room temperature. 