### PR TITLE
Correct room temperature value

### DIFF
--- a/src/Thermal/HeatTransfer/ideal_components.jl
+++ b/src/Thermal/HeatTransfer/ideal_components.jl
@@ -1,5 +1,5 @@
 """
-    HeatCapacitor(; name, C, T_start=293.15 + 20)    
+    HeatCapacitor(; name, C, T_start=273.15 + 20)    
 
 Lumped thermal element storing heat
 
@@ -11,7 +11,7 @@ Lumped thermal element storing heat
 - `T`: [K] Temperature of element
 - `der_T`: [K/s] Time derivative of temperature
 """
-function HeatCapacitor(; name, C, T_start=293.15 + 20)    
+function HeatCapacitor(; name, C, T_start=273.15 + 20)    
     @named port = HeatPort()
     @parameters C=C
     sts = @variables begin


### PR DESCRIPTION
To go from Kelvin scale to Celsius scale, add `273.15`, not `293.15`.