### PR TITLE
Make thermal models ODEs again

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -4,6 +4,7 @@ pages = [
         "Tutorials" => [
             "RC Circuit" => "tutorials/rc_circuit.md",
             "Custom Components" => "tutorials/custom_component.md",
+            "Thermal Conduction Model" => "tutorials/thermal_model.md",
         ],
 
         "API" => [

--- a/docs/src/API/thermal.md
+++ b/docs/src/API/thermal.md
@@ -34,5 +34,7 @@ TemperatureSensor
 
 ```@docs
 FixedHeatFlow
-FixedTemperature 
+FixedTemperature
+PrescribedHeatFlow
+PrescribedTemperature  
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,6 +16,7 @@ import Pkg; Pkg.add("ModelingToolkitStandardLibrary")
 
 - [RC Circuit](http://mtkstdlib.sciml.ai/dev/tutorials/rc_circuit/)
 - [Custom Component](http://mtkstdlib.sciml.ai/dev/tutorials/custom_component/)
+- [Thermal Model](http://mtkstdlib.sciml.ai/dev/tutorials/thermal_model/)
 
 ## Libraries
 

--- a/docs/src/tutorials/thermal_model.md
+++ b/docs/src/tutorials/thermal_model.md
@@ -6,7 +6,7 @@ The mass with the higher temperature will cool off while the mass with the lower
 They will each asymptotically approach the calculated temperature T_final_K that results 
 from dividing the total initial energy in the system by the sum of the heat capacities of each element.
 
-```@example
+```julia
 using ModelingToolkitStandardLibrary.Thermal, ModelingToolkit, OrdinaryDiffEq, Plots
 
 @parameters t
@@ -36,6 +36,6 @@ T_final_K = sol[(mass1.T * C1 + mass2.T * C2) / (C1 + C2)]
 plot(title = "Thermal Conduction Demonstration")
 plot!(sol, vars = [mass1.T, mass2.T], labels = ["Mass 1 Temperature" "Mass 2 Temperature"])
 plot!(sol.t, T_final_K, label = "Steady-State Temperature")
-savefig("thermal_plot.png"); nothing # hide 
+savefig("thermal_plot.png")
 ```
-![](thermal_plot.png)
+![Plot of Temperatures](https://user-images.githubusercontent.com/50108075/173061172-4c7305f5-1193-4b17-9ca4-8f8dcbc0cae7.png)

--- a/docs/src/tutorials/thermal_model.md
+++ b/docs/src/tutorials/thermal_model.md
@@ -1,0 +1,41 @@
+# Heat Conduction Model
+
+This example demonstrates the thermal response of two masses connected by a conducting element. 
+The two masses have the same heat capacity but different initial temperatures (T1=100 [°C], T2=0 [°C]). 
+The mass with the higher temperature will cool off while the mass with the lower temperature heats up. 
+They will each asymptotically approach the calculated temperature T_final_K that results 
+from dividing the total initial energy in the system by the sum of the heat capacities of each element.
+
+```@example
+using ModelingToolkitStandardLibrary.Thermal, ModelingToolkit, OrdinaryDiffEq, Plots
+
+@parameters t
+
+C1 = 15
+C2 = 15
+@named mass1 = HeatCapacitor(C=C1, T_start=373.15)
+@named mass2 = HeatCapacitor(C=C2, T_start=273.15)
+@named conduction = ThermalConductor(G=10)
+@named Tsensor1 = TemperatureSensor() 
+@named Tsensor2 = TemperatureSensor()
+
+connections = [
+    connect(mass1.port, conduction.port_a),
+    connect(conduction.port_b, mass2.port),
+    connect(mass1.port, Tsensor1.port),
+    connect(mass2.port, Tsensor2.port),
+]
+
+@named model = ODESystem(connections, t, systems=[mass1, mass2, conduction, Tsensor1, Tsensor2])
+sys = structural_simplify(model)
+prob = ODEProblem(sys, Pair[], (0, 5.0))
+sol = solve(prob, Tsit5())
+
+T_final_K = sol[(mass1.T * C1 + mass2.T * C2) / (C1 + C2)]
+
+plot(title = "Thermal Conduction Demonstration")
+plot!(sol, vars = [mass1.T, mass2.T], labels = ["Mass 1 Temperature" "Mass 2 Temperature"])
+plot!(sol.t, T_final_K, label = "Steady-State Temperature")
+savefig("thermal_plot.png"); nothing # hide 
+```
+![](thermal_plot.png)

--- a/src/Mechanical/Rotational/Rotational.jl
+++ b/src/Mechanical/Rotational/Rotational.jl
@@ -4,7 +4,6 @@ Library to model 1-dimensional, rotational mechanical systems
 module Rotational
 
 using ModelingToolkit, Symbolics, IfElse, OrdinaryDiffEq
-using OffsetArrays
 using ...Blocks: RealInput, RealOutput
 
 @parameters t

--- a/src/Thermal/HeatTransfer/ideal_components.jl
+++ b/src/Thermal/HeatTransfer/ideal_components.jl
@@ -89,28 +89,28 @@ end
 Lumped thermal element for heat convection.
 
 # States:
-- `dT`:  [`K`] Temperature difference across the component solid_port.T - fluid_port.T
-- `Q_flow`: [`W`] Heat flow rate from `solid_port` -> `fluid_port`
+- `dT`:  [`K`] Temperature difference across the component solid.T - fluid.T
+- `Q_flow`: [`W`] Heat flow rate from `solid` -> `fluid`
 
 # Connectors:
-- `solid_port`
-- `fluid_port`
+- `solid`
+- `fluid`
 
 # Parameters:
 - `G`: [W/K] Convective thermal conductance
 """
 function ConvectiveConductor(; name, G)
-    @named solid_port = HeatPort()
-    @named fluid_port = HeatPort()
+    @named solid = HeatPort()
+    @named fluid = HeatPort()
     @parameters G=G
     sts = @variables Q_flow(t) dT(t)
     eqs = [
-        dT ~ solid_port.T - fluid_port.T
-        solid_port.Q_flow ~ Q_flow
-        fluid_port.Q_flow ~ -Q_flow
+        dT ~ solid.T - fluid.T
+        solid.Q_flow ~ Q_flow
+        fluid.Q_flow ~ -Q_flow
         dT ~ G*Q_flow
     ]
-    ODESystem(eqs, t, sts, [G]; systems=[solid_port, fluid_port], name=name)
+    ODESystem(eqs, t, sts, [G]; systems=[solid, fluid], name=name)
 end
 
 """
@@ -119,28 +119,28 @@ end
 Lumped thermal element for heat convection.
 
 # States:
-- `dT`:  [`K`] Temperature difference across the component solid_port.T - fluid_port.T
-- `Q_flow`: [`W`] Heat flow rate from `solid_port` -> `fluid_port`
+- `dT`:  [`K`] Temperature difference across the component solid.T - fluid.T
+- `Q_flow`: [`W`] Heat flow rate from `solid` -> `fluid`
 
 # Connectors:
-- `solid_port`
-- `fluid_port`
+- `solid`
+- `fluid`
 
 # Parameters:
 - `R`: [`K/W`] Constant thermal resistance of material
 """
 function ConvectiveResistor(; name, R)
-    @named solid_port = HeatPort()
-    @named fluid_port = HeatPort()
+    @named solid = HeatPort()
+    @named fluid = HeatPort()
     @parameters R=R
     sts = @variables Q_flow(t) dT(t) 
     eqs = [
-        dT ~ solid_port.T - fluid_port.T
-        solid_port.Q_flow ~ Q_flow
-        fluid_port.Q_flow ~ -Q_flow
+        dT ~ solid.T - fluid.T
+        solid.Q_flow ~ Q_flow
+        fluid.Q_flow ~ -Q_flow
         dT ~ R*Q_flow
     ]
-    ODESystem(eqs, t, sts, [R]; systems=[solid_port, fluid_port], name=name)
+    ODESystem(eqs, t, sts, [R]; systems=[solid, fluid], name=name)
 end
 
 """

--- a/src/Thermal/HeatTransfer/ideal_components.jl
+++ b/src/Thermal/HeatTransfer/ideal_components.jl
@@ -22,8 +22,8 @@ function HeatCapacitor(; name, C, T_start=273.15 + 20)
     D = Differential(t)
     eqs = [
         T ~ port.T
-        der_T ~ D(T)
-        D(T) ~ port.Q_flow / C
+        der_T ~ port.Q_flow / C
+        D(T) ~ der_T
     ]
     ODESystem(eqs, t, sts, [C]; systems=[port], name=name)
 end

--- a/src/Thermal/HeatTransfer/sensors.jl
+++ b/src/Thermal/HeatTransfer/sensors.jl
@@ -6,10 +6,16 @@ Absolute temperature sensor in kelvin.
 This is an ideal absolute temperature sensor which returns the temperature of the connected port in kelvin as an output
 signal. The sensor itself has no thermal interaction with whatever it is connected to. Furthermore, no thermocouple-like 
 lags are associated with this sensor model.
+
+# States:
+- `T(t)`: [`K`] Absolute temperature
+
+# Connectors:
+- `port`
 """
 function TemperatureSensor(; name)
     @named port = HeatPort()
-    @variables T(t) # [K] Absolute temperature
+    @variables T(t)
     eqs = [
         T ~ port.T
         port.Q_flow ~ 0
@@ -24,11 +30,18 @@ Relative Temperature sensor.
 
 The relative temperature `port_a.T - port_b.T` is determined between the two ports of this component and is provided as 
 output signal in kelvin.
+
+# States:
+- `T(t)`: [`K`] Relative temperature `a.T - b.T`
+
+# Connectors:
+- `port_a`
+- `port_b`
 """
 function RelativeTemperatureSensor(; name)
     @named port_a = HeatPort()
     @named port_b = HeatPort()
-    @variables T(t) # [K] Relative temperature a.T - b.T
+    @variables T(t)
     eqs = [
         T ~ port_a.T - port_b.T
         port_a.Q_flow ~ 0
@@ -46,11 +59,18 @@ This model is capable of monitoring the heat flow rate flowing through this comp
 is the amount that passes through this sensor while keeping the temperature drop across the sensor zero. This is an ideal 
 model so it does not absorb any energy and it has no direct effect on the thermal response of a system it is included in.
 The output signal is positive, if the heat flows from `port_a` to `port_b`.
+
+# States:
+- `Q_flow(t)`: [`W`] Heat flow from `port_a` to `port_b`
+
+# Connectors:
+- `port_a`
+- `port_b`
 """
 function HeatFlowSensor(; name)
     @named port_a = HeatPort()
     @named port_b = HeatPort()
-    @variables Q_flow(t) # [W] Heat flow from port a to port b
+    @variables Q_flow(t) 
     eqs = [
         port_a.T ~ port_b.T
         port_a.Q_flow + port_b.Q_flow ~ 0

--- a/src/Thermal/HeatTransfer/sources.jl
+++ b/src/Thermal/HeatTransfer/sources.jl
@@ -7,6 +7,9 @@ This model allows a specified amount of heat flow rate to be "injected" into a t
 The constant amount of heat flow rate `Q_flow` is given as a parameter. The heat flows into the component to which
 the component FixedHeatFlow is connected, if parameter `Q_flow` is positive.
 
+# Connectors:
+- `port`
+
 # Parameters:
 - `Q_flow`: [W] Fixed heat flow rate at port
 - `T_ref`: [K] Reference temperature
@@ -31,7 +34,10 @@ end
 
 Fixed temperature boundary condition in kelvin.
 
-This model defines a fixed temperature T at its port in kelvin, i.e., it defines a fixed temperature as a boundary condition.
+This model defines a fixed temperature `T` at its port in kelvin, i.e., it defines a fixed temperature as a boundary condition.
+
+# Connectors:
+- `port`
 
 # Parameters:
 - `T`: [K] Fixed temperature boundary condition
@@ -43,4 +49,61 @@ function FixedTemperature(; name, T)
         port.T ~ T
     ]
     ODESystem(eqs, t, [], pars; systems=[port], name=name)
+end
+
+
+"""
+    PrescribedHeatFlow(; name, Q_flow=1.0, T_ref=293.15, alpha=0.0)
+
+Prescribed heat flow boundary condition.
+
+This model allows a specified amount of heat flow rate to be "injected" into a thermal system at a given port. 
+The amount of heat is given by the input signal `Q_flow` into the model. The heat flows into the component to which 
+the component `PrescribedHeatFlow` is connected, if the input signal is positive.
+If parameter alpha is > 0, the heat flow is multiplied by `1 + alpha*(port.T - T_ref`) in order to simulate temperature 
+dependent losses (which are given an reference temperature T_ref).
+
+# Connectors:
+- `port`
+- `Q_flow` Input for the heat flow
+
+# Parameters:
+- `T_ref`: [K] Reference temperature
+- `alpha`: [1/K] Temperature coefficient of heat flow rate
+"""
+function PrescribedHeatFlow(; name, T_ref=293.15, alpha=0.0)
+    pars = @parameters begin 
+        Q_flow=Q_flow 
+        T_ref=T_ref 
+        alpha=alpha
+    end
+    @named port = HeatPort()
+    @named Q_flow = RealInput()
+    
+    eqs = [
+        port.Q_flow ~ -Q_flow.u * (1 + alpha * (port.T - T_ref))
+    ]
+    ODESystem(eqs, t, [], pars; systems=[port, Q_flow], name=name)
+end
+
+"""
+    PrescribedTemperature(; name, T)
+
+This model represents a variable temperature boundary condition. 
+
+The temperature in kelvin is given as input signal `T` to the model. The effect is that an instance of 
+this model acts as an infinite reservoir able to absorb or generate as much energy as required to keep 
+the temperature at the specified value.
+
+# Connectors:
+- `port`
+- `T` input for the temperature
+"""
+function PrescribedTemperature(; name)
+    @named port = HeatPort()
+    @named T = RealInput()
+    eqs = [
+        port.T ~ T.u
+    ]
+    ODESystem(eqs, t, [], pars; systems=[port, T], name=name)
 end

--- a/src/Thermal/HeatTransfer/sources.jl
+++ b/src/Thermal/HeatTransfer/sources.jl
@@ -73,7 +73,6 @@ dependent losses (which are given an reference temperature T_ref).
 """
 function PrescribedHeatFlow(; name, T_ref=293.15, alpha=0.0)
     pars = @parameters begin 
-        Q_flow=Q_flow 
         T_ref=T_ref 
         alpha=alpha
     end
@@ -105,5 +104,5 @@ function PrescribedTemperature(; name)
     eqs = [
         port.T ~ T.u
     ]
-    ODESystem(eqs, t, [], pars; systems=[port, T], name=name)
+    ODESystem(eqs, t, [], []; systems=[port, T], name=name)
 end

--- a/src/Thermal/Thermal.jl
+++ b/src/Thermal/Thermal.jl
@@ -2,30 +2,27 @@
 Library of thermal system components to model heat transfer.
 """
 module Thermal
-using ModelingToolkit, Symbolics, IfElse, OrdinaryDiffEq
+using ModelingToolkit, Symbolics, IfElse
+using ...Blocks: RealInput, RealOutput
 
 @parameters t
 D = Differential(t)
 
+export HeatPort, Element1D
 include("utils.jl")
 
-# Library of 1-dimensional heat transfer with lumped elements
+export BodyRadiation, ConvectiveConductor, ConvectiveResistor, HeatCapacitor, ThermalConductor, 
+       ThermalResistor, ThermalCollector
 include("HeatTransfer/ideal_components.jl")
+
+export RelativeTemperatureSensor, HeatFlowSensor, TemperatureSensor
 include("HeatTransfer/sensors.jl")
+
+export FixedHeatFlow, FixedTemperature, PrescribedHeatFlow, PrescribedTemperature
 include("HeatTransfer/sources.jl")
 
 # Simple components for 1-dimensional incompressible thermo-fluid flow models
 # TODO:
 # - FluidHeatFlow
-
-export # Interface
-       HeatPort,
-       # Thermal Components
-       BodyRadiation, ConvectiveConductor, ConvectiveResistor,
-       HeatCapacitor, ThermalConductor, ThermalResistor, ThermalCollector,
-       # Thermal Sensors
-       RelativeTemperatureSensor, HeatFlowSensor, TemperatureSensor,
-       # Thermal Sources
-       FixedHeatFlow, FixedTemperature, ThermalGround 
 
 end

--- a/src/Thermal/utils.jl
+++ b/src/Thermal/utils.jl
@@ -8,13 +8,13 @@ Base.@doc """
 
 Port for a thermal system.
 
-# Parameters:
-- `T_start`: [K] Temperature of the port  
-- `Q_flow_start`: [W] Heat flow rate at the port
-
 # States:
 - `T`: [K] Temperature of the port  
 - `Q_flow`: [W] Heat flow rate at the port
+
+# Parameters:
+- `T_start`: [K] Temperature of the port  
+- `Q_flow_start`: [W] Heat flow rate at the port
 """ HeatPort
 
 """
@@ -24,13 +24,17 @@ This partial model contains the basic connectors and variables to allow heat tra
 store energy. This model defines and includes equations for the temperature drop across the element, `dT`, and the heat
 flow rate through the element from `port_a` to `port_b`, `Q_flow`.
 
+# States:
+- `dT`:  [`K`] Temperature difference across the component a.T - b.T
+- `Q_flow`: [`W`] Heat flow rate from port a -> port b
+
+# Connectors:
+`port_a`
+`port_b`
+
 # Parameters:
 - `dT_start`:  [K] Initial temperature difference across the component a.T - b.T
 - `Q_flow_start`: [W] Initial heat flow rate from port a -> port b
-
-# States:
-- `dT`:  [K] Temperature difference across the component a.T - b.T
-- `Q_flow`: [W] Heat flow rate from port a -> port b
 """
 function Element1D(;name, dT_start=0.0, Q_flow_start=0.0)
     @named port_a = HeatPort()

--- a/test/Thermal/demo.jl
+++ b/test/Thermal/demo.jl
@@ -19,7 +19,7 @@ begin
 
     @named model = ODESystem(connections, t, systems=[mass1, mass2, conduction, Tsensor1, Tsensor2])
     sys = structural_simplify(model)
-    prob = DAEProblem(sys, D.(states(sys)) .=> 0.0, [mass1.der_T => 1.0, mass2.der_T => 1.0], (0, 3.0))
-    sol = solve(prob, DFBDF())
+    prob = ODEProblem(sys, [mass1.der_T => 1.0, mass2.der_T => 1.0], (0, 3.0))
+    sol = solve(prob, Tsit5())
     @test sol.retcode == :Success
 end

--- a/test/Thermal/demo.jl
+++ b/test/Thermal/demo.jl
@@ -3,7 +3,7 @@ using ModelingToolkitStandardLibrary.Thermal, ModelingToolkit, OrdinaryDiffEq, T
 D = Differential(t)
 
 # Modelica example
-begin
+@testset "demo" begin
     @named mass1 = HeatCapacitor(C=15, T_start=373.15)
     @named mass2 = HeatCapacitor(C=15, T_start=273.15)
     @named conduction = ThermalConductor(G=10)

--- a/test/Thermal/thermal.jl
+++ b/test/Thermal/thermal.jl
@@ -129,7 +129,7 @@ end
         wall.Q_flow => 10.0
     ]
     prob = ODEProblem(sys, u0, (0, 3.0))
-    sol = solve(prob, Tsit5())
+    sol = solve(prob, Rodas4())
 
     # Heat-flow-rate is equal in magnitude
     # and opposite in direction
@@ -165,7 +165,7 @@ end
         mass.T => T_gas
     ]
     prob = ODEProblem(sys, u0, (0, 3.0))
-    sol = solve(prob, Tsit5())
+    sol = solve(prob, Rodas4())
 
     @test sol.retcode == :Success
     @test sol[dissipator.dT] == sol[radiator.port_a.T] - sol[radiator.port_b.T]
@@ -200,7 +200,7 @@ end
         mass.T => 0.0,
     ]
     prob = ODEProblem(sys, u0, (0, 3.0))
-    sol  = solve(prob, Tsit5())
+    sol  = solve(prob, Rodas4())
 
     @test sol.retcode == :Success
     @test sol[collector.port_b.Q_flow] + sol[collector.port_a1.Q_flow] + sol[collector.port_a2.Q_flow] ==

--- a/test/Thermal/thermal.jl
+++ b/test/Thermal/thermal.jl
@@ -1,4 +1,5 @@
 using ModelingToolkitStandardLibrary.Thermal, ModelingToolkit, OrdinaryDiffEq, Test
+using ModelingToolkitStandardLibrary.Blocks: Constant, Step
 @parameters t
 D = Differential(t)
 
@@ -40,10 +41,10 @@ D = Differential(t)
         connect(T_sensor1.port, mass1.port, th_conductor.port_a)
         connect(th_conductor.port_b, mass2.port, T_sensor2.port)
         final_T ~ (mass1.C * mass1.T + mass2.C * mass2.T) /
-        (mass1.C + mass2.C)
+                  (mass1.C + mass2.C)
     ]
     @named h2 = ODESystem(eqs, t, [final_T], [],
-                        systems=[mass1, mass2, T_sensor1, T_sensor2, th_conductor])
+        systems=[mass1, mass2, T_sensor1, T_sensor2, th_conductor])
     sys = structural_simplify(h2)
 
     u0 = [
@@ -58,7 +59,7 @@ D = Differential(t)
 
     @test sol.retcode == :Success
     m1, m2 = sol.u[end]
-    @test m1 ≈ m2 atol=1e-1
+    @test m1 ≈ m2 atol = 1e-1
     mass_T = reduce(hcat, sol.u)
     @test sol[T_sensor1.T] == mass_T[1, :]
     @test sol[T_sensor2.T] == mass_T[2, :]
@@ -82,14 +83,14 @@ end
         connect(th_resistor.port_b, hf_sensor1.port_b, hf_sensor2.port_b, th_ground.port)
     ]
     @named h2 = ODESystem(eqs, t,
-                          systems=[mass1, hf_sensor1, hf_sensor2,
-                                   th_resistor, flow_src, th_ground, th_conductor])
+        systems=[mass1, hf_sensor1, hf_sensor2,
+            th_resistor, flow_src, th_ground, th_conductor])
     sys = structural_simplify(h2)
 
     u0 = [
         mass1.T => 10.0
         th_resistor.Q_flow => 1.0
-        mass1.der_T        => 1.0
+        mass1.der_T => 1.0
     ]
     prob = ODEProblem(sys, u0, (0, 3.0))
     sol = solve(prob, Tsit5())
@@ -116,10 +117,10 @@ end
 
     @info "Building a piston-cylinder..."
     eqs = [
-        connect(gas_tem.port, gas.solid_port)
-        connect(gas.fluid_port, wall.port_a)
-        connect(wall.port_b, coolant.fluid_port)
-        connect(coolant.solid_port, coolant_tem.port)
+        connect(gas_tem.port, gas.solid)
+        connect(gas.fluid, wall.port_a)
+        connect(wall.port_b, coolant.fluid)
+        connect(coolant.solid, coolant_tem.port)
     ]
     @named piston = ODESystem(eqs, t, systems=[gas_tem, wall, gas, coolant, coolant_tem])
     sys = structural_simplify(piston)
@@ -153,8 +154,8 @@ end
 
     @info "Building a radiator..."
     eqs = [
-        connect(gas_tem.port, radiator.port_a, base.port_a, dissipator.solid_port, mass.port)
-        connect(coolant_tem.port, base.port_b, radiator.port_b, dissipator.fluid_port)
+        connect(gas_tem.port, radiator.port_a, base.port_a, dissipator.solid, mass.port)
+        connect(coolant_tem.port, base.port_b, radiator.port_b, dissipator.fluid)
     ]
     @named rad = ODESystem(eqs, t, systems=[base, gas_tem, radiator, dissipator, coolant_tem, mass])
     sys = structural_simplify(rad)
@@ -169,7 +170,7 @@ end
 
     @test sol.retcode == :Success
     @test sol[dissipator.dT] == sol[radiator.port_a.T] - sol[radiator.port_b.T]
-    rad_Q_flow = G*σ*(T_gas^4 - T_coolant^4)
+    rad_Q_flow = G * σ * (T_gas^4 - T_coolant^4)
     @test sol[radiator.Q_flow] == fill(rad_Q_flow, length(sol[radiator.Q_flow]))
 end
 
@@ -189,10 +190,10 @@ end
         connect(hf_sensor.port_a, collector.port_b)
         connect(hf_sensor.port_b, mass.port, th_resistor.port_b)
         connect(mass.port, th_ground.port)
-        ]
+    ]
     @named coll = ODESystem(eqs, t,
-                            systems=[hf_sensor,flow_src, tem_src,
-                            collector, th_resistor, mass])
+        systems=[hf_sensor, flow_src, tem_src,
+            collector, th_resistor, mass])
     sys = structural_simplify(coll)
 
     u0 = [
@@ -200,10 +201,56 @@ end
         mass.T => 0.0,
     ]
     prob = ODEProblem(sys, u0, (0, 3.0))
-    sol  = solve(prob, Rodas4())
+    sol = solve(prob, Rodas4())
 
     @test sol.retcode == :Success
     @test sol[collector.port_b.Q_flow] + sol[collector.port_a1.Q_flow] + sol[collector.port_a2.Q_flow] ==
-        zeros(length(sol[collector.port_b.Q_flow]))
+          zeros(length(sol[collector.port_b.Q_flow]))
     @test sol[collector.port_b.T] == sol[collector.port_a1.T] == sol[collector.port_a2.T]
+end
+
+# https://doc.modelica.org/Modelica%204.0.0/Resources/helpWSM/Modelica/Modelica.Thermal.HeatTransfer.Examples.Motor.html
+@testset "demo" begin
+    k2c(T) = T - 273.15
+    T_amb = 293.15
+    @named windingLosses = PrescribedHeatFlow(T_ref=k2c(95), alpha=3.03e-3)
+    @named winding = HeatCapacitor(C=2500, T_start=T_amb)
+    @named T_winding = TemperatureSensor()
+    @named winding2core = ThermalConductor(G=10)
+    @named coreLosses = PrescribedHeatFlow()
+    @named core = HeatCapacitor(C=25000, T_start=T_amb)
+    @named T_core = TemperatureSensor()
+    @named convection = ConvectiveConductor(G=25)
+    @named environment = PrescribedTemperature()
+    @named amb = Constant(k=T_amb)
+    @named core_losses_const = Constant(k=500)
+    @named winding_losses = Step(height=900, offset=100, start_time=360, duration=Inf, smooth=false)
+    connections = [ 
+        connect(windingLosses.port, winding.port)
+        connect(coreLosses.port, core.port)
+        connect(winding.port, winding2core.port_a)
+        connect(winding2core.port_b, core.port)
+        connect(winding.port, T_winding.port)
+        connect(core.port, T_core.port)
+        connect(winding2core.port_b, convection.solid)
+        connect(convection.fluid, environment.port)
+        connect(amb.output, environment.T)
+        connect(winding_losses.output, windingLosses.Q_flow)
+        connect(core_losses_const.output, coreLosses.Q_flow)
+    ]
+
+    @named model = ODESystem(connections, t, systems=[
+        windingLosses, winding, T_winding, winding2core, coreLosses, core,
+        T_core, convection, environment, amb, core_losses_const, winding_losses])
+    sys = structural_simplify(model)
+    prob = ODEProblem(sys, Pair[], (0, 720.0))
+    sol = solve(prob, Rodas4())
+
+    # plot(sol; vars=[T_winding.T, T_core.T])
+    @test sol.retcode == :Success
+    @test sol[T_winding.T] == sol[winding.T]
+    @test sol[T_core.T] == sol[core.T]
+    @test sol[-core.port.Q_flow] == sol[coreLosses.port.Q_flow + convection.solid.Q_flow + winding2core.port_b.Q_flow]
+    @test sol[T_winding.T][end] >= 500 # not good but better than nothing
+    @test sol[T_core.T] <= sol[T_winding.T]
 end


### PR DESCRIPTION
# Breaking Changes:
- Renames ports of `ConvectiveResistor` (`solidport` to `solid` and `fluidport` to `fluid`) to be the same as `ConvectiveConductor`.

# New Components:
- `PrescribedHeatFlow`
- `PrescribedTemperature`