### PR TITLE
Add analysis points

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,8 +19,9 @@ Symbolics = "0.1, 1, 2, 3, 4"
 julia = "1.6"
 
 [extras]
+ControlSystemsBase = "aaaaaaaa-a6ca-5380-bf3e-84a91bcd477e"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["SafeTestsets", "Test"]
+test = ["SafeTestsets", "Test", "ControlSystemsBase"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ControlSystemsBase = "aaaaaaaa-a6ca-5380-bf3e-84a91bcd477e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -11,5 +11,6 @@ pages = [
         "Magnetic Components" => "API/magnetic.md",
         "Mechanical Components" => "API/mechanical.md",
         "Thermal Components" => "API/thermal.md",
+        "Linear Analysis" => "API/linear_analysis.md",
     ],
 ]

--- a/docs/src/API/linear_analysis.md
+++ b/docs/src/API/linear_analysis.md
@@ -1,11 +1,14 @@
 # Linear Analysis
 
-Linear analysis refers to the process of linearizing a nonlinear model and analysing the resulting linear dynamical system. To facilitate linear analysis, ModelingToolkitStandardLibrary provides the concept of an [`AnalysisPoint`](@ref), which can be inserted inbetween two causal blocks (such as those from the Blocks sub module). Once a model containing analysis points is built, several operations are available:
+!!! danger "Experimental"
+    The interface described here is currently experimental and at any time subject to breaking changes not respecting semantic versioning. 
+
+Linear analysis refers to the process of linearizing a nonlinear model and analysing the resulting linear dynamical system. To facilitate linear analysis, ModelingToolkitStandardLibrary provides the concept of an [`AnalysisPoint`](@ref), which can be inserted in-between two causal blocks (such as those from the `Blocks` sub module). Once a model containing analysis points is built, several operations are available:
 
 - [`get_sensitivity`](@ref) get the [sensitivity function (wiki)](https://en.wikipedia.org/wiki/Sensitivity_(control_systems)), $S(s)$, as defined in the field of control theory.
-- [`get_comp_sensitivity`](@ref) get the complementary sensitivy function $T(s) : S(s)+T(s)=1$.
+- [`get_comp_sensitivity`](@ref) get the complementary sensitivity function $T(s) : S(s)+T(s)=1$.
 - [`get_looptransfer`](@ref) get the (open) loop-transfer function where the loop starts and ends in the analysis point.
-- [`linearize`](@ref) can be called with two analysis points denoting the input and output of the linearied system. Parts of the model not appearing between the input and output will be removed.
+- [`linearize`](@ref) can be called with two analysis points denoting the input and output of the linearized system. Parts of the model not appearing between the input and output will be removed.
 - [`open_loop`](@ref) return a new (nonlinear) system where the loop has been broken in the analysis point, i.e., the connection the analysis point usually implies has been removed.
 
 An analysis point can be created explicitly using the constructor [`AnalysisPoint`](@ref), or automatically when connecting two causal components using `connect`:

--- a/docs/src/API/linear_analysis.md
+++ b/docs/src/API/linear_analysis.md
@@ -1,0 +1,97 @@
+# Linear Analysis
+
+Linear analysis refers to the process of linearizing a nonlinear model and analysing the resulting linear dynamical system. To facilitate linear analysis, ModelingToolkitStandardLibrary provides the concept of an [`AnalysisPoint`](@ref), which can be inserted inbetween two causal blocks (such as those from the Blocks sub module). Once a model containing analysis points is built, several operations are available:
+
+- [`get_sensitivity`](@ref) get the [sensitivity function (wiki)](https://en.wikipedia.org/wiki/Sensitivity_(control_systems)), $S(s)$, as defined in the field of control theory.
+- [`get_comp_sensitivity`](@ref) get the complementary sensitivy function $T(s) : S(s)+T(s)=1$.
+- [`get_looptransfer`](@ref) get the (open) loop-transfer function where the loop starts and ends in the analysis point.
+- [`linearize`](@ref) can be called with two analysis points denoting the input and output of the linearied system. Parts of the model not appearing between the input and output will be removed.
+- [`open_loop`](@ref) return a new (nonlinear) system where the loop has been broken in the analysis point, i.e., the connection the analysis point usually implies has been removed.
+
+An analysis point can be created explicitly using the constructor [`AnalysisPoint`](@ref), or automatically when connecting two causal components using `connect`:
+```julia
+connect(comp1.output, :analysis_point_name, comp2.input)
+```
+
+Of the above mentioned functions, all except for [`open_loop`](@ref) return the output of [`ModelingToolkit.linearize`](@ref), which is
+```julia
+matrices, simplified_sys = linearize(...)
+# matrices = (; A, B, C, D)
+```
+i.e., `matrices` is a named tuple containing the matrices of a linear state-space system on the form
+```math
+\begin{aligned}
+\dot x &= Ax + Bu\\
+y &= Cx + Du
+\end{aligned}
+```
+
+## Example
+The following example builds a simple closed-loop system with a plant $P$ and a controller $C$. Two analysis points are inserted, one before and one after $P$. We then derive a number of sensitivity functions and show the corresponding code using the package ControlSystemBase.jl
+
+```@example LINEAR_ANALYSIS
+using ModelingToolkitStandardLibrary.Blocks, ModelingToolkit
+@named P = FirstOrder(k=1, T=1) # A first-order system with pole in -1
+@named C = Gain(-1)             # A P controller
+t = ModelingToolkit.get_iv(P)
+eqs = [
+    connect(P.output, :plant_output, C.input)  # Connect with an automatically created analysis point called :plant_output
+    connect(C.output, :plant_input, P.input)   # Connect with an automatically created analysis point called :plant_input
+]
+sys = ODESystem(eqs, t, systems=[P,C], name=:feedback_system)
+
+matrices_S = get_sensitivity(sys, :plant_input)[1] # Compute the matrices of a state-space representation of the (input)sensitivity function.
+matrices_T = get_comp_sensitivity(sys, :plant_input)[1]
+```
+Continued linear analysis and design can be performed using ControlSystemsBase.jl.
+We create `ControlSystemsBase.StateSpace` objects using
+```@example LINEAR_ANALYSIS
+using ControlSystemsBase, Plots
+S = ss(matrices_S...)
+T = ss(matrices_T...)
+bodeplot([S, T], lab=["S" "" "T" ""])
+```
+
+The sensitivity functions obtained this way should be equivalent to the ones obtained with the code below
+
+```@example LINEAR_ANALYSIS_CS
+using ControlSystemsBase
+P = tf(1.0, [1, 1]) |> ss
+C = 1                      # Negative feedback assumed in ControlSystems
+S = sensitivity(P, C)      # or feedback(1, P*C)
+T = comp_sensitivity(P, C) # or feedback(P*C)
+```
+
+We may also derive the loop-transfer function $L(s) = P(s)C(s)$ using
+
+```@example LINEAR_ANALYSIS
+matrices_L = get_looptransfer(sys, :plant_output)[1]
+L = ss(matrices_L...)
+```
+which is equivalent to the following with ControlSystems
+```@example LINEAR_ANALYSIS_CS
+L = P*(-C) # Add the minus sign to build the negative feedback into the controller
+```
+
+
+To obtain the transfer function between two analysis points, we call `linearize`
+```@example LINEAR_ANALYSIS
+matrices_P = linearize(sys, :plant_input, :plant_output)[1]
+```
+this particular transfer function should be equivalent to the linear system `P`, i.e., equivalent to this call
+```@example LINEAR_ANALYSIS
+@unpack input, output = P # To get the correct namespace
+linearize(P, [input.u], [output.u])[1]
+```
+
+## Index
+```@index
+Pages = ["linear_analysis.md"]
+```
+
+```@autodocs
+Modules = [ModelingToolkitStandardLibrary.Blocks]
+Pages   = ["Blocks/analysis_points.jl"]
+Order   = [:function, :type]
+Private = false
+```

--- a/src/Blocks/Blocks.jl
+++ b/src/Blocks/Blocks.jl
@@ -26,7 +26,8 @@ export Integrator, Derivative, FirstOrder, SecondOrder, StateSpace
 export PI, LimPI, PID, LimPID
 include("continuous.jl")
 
-export AnalysisPoint, expand_analysis_points, get_sensitivity, get_comp_sensitivity
+export AnalysisPoint, expand_analysis_points, get_sensitivity, get_comp_sensitivity,
+       get_looptransfer
 include("analysis_points.jl")
 
 end

--- a/src/Blocks/Blocks.jl
+++ b/src/Blocks/Blocks.jl
@@ -27,7 +27,7 @@ export PI, LimPI, PID, LimPID
 include("continuous.jl")
 
 export AnalysisPoint, expand_analysis_points, get_sensitivity, get_comp_sensitivity,
-       get_looptransfer
+       get_looptransfer, open_loop
 include("analysis_points.jl")
 
 end

--- a/src/Blocks/Blocks.jl
+++ b/src/Blocks/Blocks.jl
@@ -26,4 +26,7 @@ export Integrator, Derivative, FirstOrder, SecondOrder, StateSpace
 export PI, LimPI, PID, LimPID
 include("continuous.jl")
 
+export AnalysisPoint, expand_analysis_points, get_sensitivity, get_comp_sensitivity
+include("analysis_points.jl")
+
 end

--- a/src/Blocks/analysis_points.jl
+++ b/src/Blocks/analysis_points.jl
@@ -149,6 +149,7 @@ function get_sensitivity(sys, ap::AnalysisPoint; kwargs...)
     end
     @set! sys.eqs = new_eqs
     @set! sys.states = [states(sys); d]
+    sys = expand_analysis_points(sys)
     ModelingToolkit.linearize(sys, [d], [ap.out.u]; kwargs...)
 end
 
@@ -172,6 +173,7 @@ function get_comp_sensitivity(sys, ap::AnalysisPoint; kwargs...)
     end
     @set! sys.eqs = new_eqs
     @set! sys.states = [states(sys); d]
+    sys = expand_analysis_points(sys)
     ModelingToolkit.linearize(sys, [d], [ap.in.u]; kwargs...)
 end
 
@@ -193,6 +195,7 @@ function get_looptransfer(sys, ap::AnalysisPoint; kwargs...)
         0 ~ 0 # we just want to open the connection
     end
     @set! sys.eqs = new_eqs
+    sys = expand_analysis_points(sys)
     ModelingToolkit.linearize(sys, [ap.out.u], [ap.in.u]; kwargs...)
 end
 

--- a/src/Blocks/analysis_points.jl
+++ b/src/Blocks/analysis_points.jl
@@ -1,0 +1,183 @@
+using ModelingToolkit: get_eqs, vars, @set!, get_iv
+
+Base.@kwdef mutable struct AnalysisPoint
+    in = nothing
+    out = nothing
+    name::Symbol
+end
+
+"""
+    AnalysisPoint(in, out, name::Symbol)
+    AnalysisPoint(in, out; name::Symbol)
+    AnalysisPoint(name::Symbol)
+
+Create an AnalysisPoint for linear analysis. Analysis points can also e created automatically by calling 
+```
+connect(in, :ap_name, out)
+```
+
+# Arguments:
+- `in`: A connector of type [`RealOutput`](@ref).
+- `out`: A connector of type [`RealInput`](@ref).
+- `name`: The name of the analysis point.
+
+See also [`get_sensitivity`](@ref), [`get_comp_sensitivity`](@ref)
+
+# Example
+```julia
+using ModelingToolkitStandardLibrary.Blocks
+@named P = FirstOrder(k=1, T=1)
+@named C = Gain(-1)
+t = ModelingToolkit.get_iv(P)
+eqs = [
+    connect(P.output, C.input)
+    connect(C.output, :plant_input, P.input)   # Connect with an automatically created analysis point
+]
+sys = ODESystem(eqs, t, systems=[P,C], name=:feedback_system)
+
+matrices_S, _ = get_sensitivity(sys, :plant_input) # Compute the matrices of a state-space representation of the (input) sensitivity funciton.
+matrices_T, _ = get_comp_sensitivity(sys, :plant_input)
+```
+Continued linear analysis and design can be performed using ControlSystemsBase.jl.
+Create `ControlSystemsBase.StateSpace` objects using
+```julia
+using ControlSystemsBase, Plots
+S = ss(matrices_S...)
+T = ss(matrices_T...)
+bodeplot([S, T], lab=["S" "T"])
+```
+The sensitivity functions obtained this way should be equivalent to the ones obtained with the code below
+```
+using ControlSystemsBase
+P = tf(1.0, [1, 1])
+C = 1                      # Negative feedback assumed in ControlSystems
+S = sensitivity(P, C)      # or feedback(1, P*C)
+T = comp_sensitivity(P, C) # or feedback(P*C)
+```
+"""
+AnalysisPoint(in, out; name) = AnalysisPoint(in, out, name)
+AnalysisPoint(name) = AnalysisPoint(; name)
+
+Base.show(io::IO, ap::AnalysisPoint) = show(io, MIME"text/plain"(), ap)
+function Base.show(io::IO, ::MIME"text/plain", ap::AnalysisPoint)
+    if get(io, :compact, false)
+        print(io, "AnalysisPoint($(ap.in.u), $(ap.out.u); name=$(ap.name))")
+    else
+        print(io, "AnalysisPoint(")
+        printstyled(io, ap.name, color = :cyan)
+        if ap.in !== nothing && ap.out !== nothing
+            print(io, " from ")
+            printstyled(io, ap.in.u, color = :green)
+            print(io, " to ")
+            printstyled(io, ap.out.u, color = :blue)
+        end
+        print(io, ")")
+    end
+end
+
+"""
+    connect(in, ap::AnalysisPoint, out)
+    connect(in, ap_name::Symbol, out)
+
+Connect `in` and `out` with an [`AnalysisPoint`](@ref) inbetween.
+The incoming connection `in` is expected to be of type [`RealOutput`](@ref), and vice versa.
+
+# Arguments:
+- `in`: A connector of type [`RealOutput`](@ref)
+- `out`: A connector of type [`RealInput`](@ref)
+- `ap`: An explicitly created [`AnalysisPoint`](@ref)
+- `ap_name`: If a name is given, an [`AnalysisPoint`](@ref) with the given name will be created automatically.
+"""
+function ModelingToolkit.connect(in, ap::AnalysisPoint, out)
+    ap.in = in
+    ap.out = out
+    return 0 ~ ap
+end
+
+function ModelingToolkit.connect(in, ap_name::Symbol, out)
+    return 0 ~ AnalysisPoint(in, out, ap_name)
+end
+
+function ModelingToolkit.vars(ap::AnalysisPoint; op = Differential)
+    vars(connect(ap.in, ap.out); op)
+end
+
+"""
+    find_analysis_point(sys, name::Symbol)
+
+Find and return the analysis point in `sys` with the specified `name`. If no matching [`AnalysisPoint`](@ref) is found, `nothing` is returned.
+"""
+function find_analysis_point(sys, name)
+    for eq in equations(sys)
+        eq.rhs isa AnalysisPoint && eq.rhs.name == name && (return eq.rhs)
+    end
+    nothing
+end
+
+"""
+    expand_analysis_points(sys)
+
+Replace analysis points with the identity connection connect(ap.in, ap.out). This is called before a system containing analysis points is simulated, in which case analysis points have no effect.
+"""
+function expand_analysis_points(sys)
+    new_eqs = map(get_eqs(sys)) do eq
+        eq.rhs isa AnalysisPoint || (return eq)
+        ap = eq.rhs
+        connect(ap.in, ap.out)
+    end
+    @set! sys.eqs = new_eqs
+    sys
+end
+
+"""
+    get_sensitivity(sys, ap::AnalysisPoint; kwargs)
+    get_sensitivity(sys, ap_name::Symbol; kwargs)
+
+Compute the sensitivity function in analysis point `ap`. The sensitivity function is obtained by introducing an infinitesimal perturbation `d` at the input of `ap`, linearizing the system and computing the transfer function between `d` and the output of `ap`.
+
+# Arguments:
+- `kwargs`: Are sent to `ModelingToolkit.linearize`
+
+See also [`get_comp_sensitivity`](@ref).
+"""
+function get_sensitivity(sys, ap::AnalysisPoint; kwargs...)
+    t = get_iv(sys)
+    @variables d(t) = 0 # Perturbantion serving as input to sensivity transfer function
+    new_eqs = map(get_eqs(sys)) do eq
+        eq.rhs == ap || (return eq)
+        ap.out.u ~ ap.in.u + d # This assumes that the connector as an internal vaiable named u
+    end
+    @set! sys.eqs = new_eqs
+    @set! sys.states = [states(sys); d]
+    ModelingToolkit.linearize(sys, [d], [ap.out.u]; kwargs...)
+end
+
+"""
+    get_comp_sensitivity(sys, ap::AnalysisPoint; kwargs)
+    get_comp_sensitivity(sys, ap_name::Symbol; kwargs)
+
+Compute the complementary sensitivity function in analysis point `ap`. The complementary sensitivity function is obtained by introducing an infinitesimal perturbation `d` at the output of `ap`, linearizing the system and computing the transfer function between `d` and the input of `ap`.
+
+# Arguments:
+- `kwargs`: Are sent to `ModelingToolkit.linearize`
+
+See also [`get_sensitivity`](@ref).
+"""
+function get_comp_sensitivity(sys, ap::AnalysisPoint; kwargs...)
+    t = get_iv(sys)
+    @variables d(t) = 0 # Perturbantion serving as input to sensivity transfer function
+    new_eqs = map(get_eqs(sys)) do eq
+        eq.rhs == ap || (return eq)
+        ap.out.u + d ~ ap.in.u # This assumes that the connector as an internal vaiable named u
+    end
+    @set! sys.eqs = new_eqs
+    @set! sys.states = [states(sys); d]
+    ModelingToolkit.linearize(sys, [d], [ap.in.u]; kwargs...)
+end
+
+# Add a method to get_sensitivity that accepts the name of an AnalysisPoint 
+for f in [:get_sensitivity, :get_comp_sensitivity]
+    @eval function $f(sys, ap_name::Symbol, args...; kwargs...)
+        $f(sys, find_analysis_point(sys, ap_name), args...; kwargs...)
+    end
+end

--- a/src/Blocks/analysis_points.jl
+++ b/src/Blocks/analysis_points.jl
@@ -16,6 +16,9 @@ Create an AnalysisPoint for linear analysis. Analysis points can also be created
 connect(in, :ap_name, out)
 ```
 
+!!! danger "Experimental"
+    The analysis-point interface is currently experimental and at any time subject to breaking changes not respecting semantic versioning. 
+
 # Arguments:
 - `in`: A connector of type [`RealOutput`](@ref).
 - `out`: A connector of type [`RealInput`](@ref).
@@ -149,6 +152,9 @@ end
 
 Compute the sensitivity function in analysis point `ap`. The sensitivity function is obtained by introducing an infinitesimal perturbation `d` at the input of `ap`, linearizing the system and computing the transfer function between `d` and the output of `ap`.
 
+!!! danger "Experimental"
+    The analysis-point interface is currently experimental and at any time subject to breaking changes not respecting semantic versioning. 
+
 # Arguments:
 - `kwargs`: Are sent to `ModelingToolkit.linearize`
 
@@ -177,6 +183,9 @@ end
     get_comp_sensitivity(sys, ap_name::Symbol; kwargs)
 
 Compute the complementary sensitivity function in analysis point `ap`. The complementary sensitivity function is obtained by introducing an infinitesimal perturbation `d` at the output of `ap`, linearizing the system and computing the transfer function between `d` and the input of `ap`.
+
+!!! danger "Experimental"
+    The analysis-point interface is currently experimental and at any time subject to breaking changes not respecting semantic versioning. 
 
 # Arguments:
 - `kwargs`: Are sent to `ModelingToolkit.linearize`
@@ -208,6 +217,9 @@ end
 
 Compute the (linearized) loop-transfer function in analysis point `ap`, from `ap.out` to `ap.in`.
 
+!!! danger "Experimental"
+    The analysis-point interface is currently experimental and at any time subject to breaking changes not respecting semantic versioning. 
+
 # Arguments:
 - `kwargs`: Are sent to `ModelingToolkit.linearize`
 
@@ -235,6 +247,9 @@ end
 Open the loop at analysis point `ap` by breaking the connection through `ap`.
 
 `open_sys` will have `u ~ ap.out` as input and `y ~ ap.in` as output.
+
+!!! danger "Experimental"
+    The analysis-point interface is currently experimental and at any time subject to breaking changes not respecting semantic versioning. 
 
 # Arguments:
 - `kwargs`: Are sent to `ModelingToolkit.linearize`

--- a/test/Blocks/test_analysis_points.jl
+++ b/test/Blocks/test_analysis_points.jl
@@ -87,3 +87,9 @@ matrices, _ = get_sensitivity(sys, :plant_input)
 @test matrices.A[] == -2
 @test matrices.B[] * matrices.C[] == -1 # either one negative
 @test matrices.D[] == 1
+
+## Test linearize between analysis points
+matrices, _ = linearize(sys, :plant_input, :plant_output)
+@test matrices.A[] == -1
+@test matrices.B[] * matrices.C[] == 1 # both positive
+@test matrices.D[] == 0

--- a/test/Blocks/test_analysis_points.jl
+++ b/test/Blocks/test_analysis_points.jl
@@ -67,3 +67,13 @@ P = tf(1.0, [1, 1])
 C = -1
 L = P*C
 =#
+
+# Open loop
+open_sys = Blocks.open_loop(sys, :plant_input)
+@unpack u, y = open_sys
+
+# Linearizing the open-loop system should yield the same system as get_looptransfer
+matrices, _ = linearize(open_sys, [u], [y])
+@test matrices.A[] == -1
+@test matrices.B[] * matrices.C[] == -1 # either one negative
+@test matrices.D[] == 0

--- a/test/Blocks/test_analysis_points.jl
+++ b/test/Blocks/test_analysis_points.jl
@@ -77,3 +77,13 @@ matrices, _ = linearize(open_sys, [u], [y])
 @test matrices.A[] == -1
 @test matrices.B[] * matrices.C[] == -1 # either one negative
 @test matrices.D[] == 0
+
+# Test with more than one AnalysisPoint
+eqs = [connect(P.output, :plant_output, C.input)
+       connect(C.output, :plant_input, P.input)]
+sys = ODESystem(eqs, t, systems = [P, C], name = :hej)
+
+matrices, _ = get_sensitivity(sys, :plant_input)
+@test matrices.A[] == -2
+@test matrices.B[] * matrices.C[] == -1 # either one negative
+@test matrices.D[] == 1

--- a/test/Blocks/test_analysis_points.jl
+++ b/test/Blocks/test_analysis_points.jl
@@ -53,3 +53,17 @@ matrices, _ = get_comp_sensitivity(sys, :plant_input)
 @test matrices.A[] == -2
 @test matrices.B[] * matrices.C[] == 1 # both positive
 @test matrices.D[] == 0
+
+## get_looptransfer
+
+matrices, _ = Blocks.get_looptransfer(sys, :plant_input)
+@test matrices.A[] == -1
+@test matrices.B[] * matrices.C[] == -1 # either one negative
+@test matrices.D[] == 0
+#=
+# Equivalent code using ControlSystems. This can be used to verify the expected results tested for above.
+using ControlSystemsBase
+P = tf(1.0, [1, 1])
+C = -1
+L = P*C
+=#

--- a/test/Blocks/test_analysis_points.jl
+++ b/test/Blocks/test_analysis_points.jl
@@ -1,0 +1,55 @@
+using ModelingToolkit
+using ModelingToolkitStandardLibrary.Blocks
+using OrdinaryDiffEq
+using ModelingToolkit: get_eqs, vars, @set!, get_iv
+
+@named P = FirstOrder(k = 1, T = 1)
+@named C = Gain(-1)
+t = ModelingToolkit.get_iv(P)
+
+# Test with explicitly created AnalysisPoint
+ap = AnalysisPoint(:plant_input)
+eqs = [connect(P.output, C.input)
+       connect(C.output, ap, P.input)]
+sys = ODESystem(eqs, t, systems = [P, C], name = :hej)
+
+ssys = structural_simplify(expand_analysis_points(sys))
+prob = ODEProblem(ssys, [P.x => 1], (0, 10))
+sol = solve(prob, Rodas5())
+@test norm(sol[1]) >= 1
+@test norm(sol[end]) < 1e-6 # This fails without the feedback through C
+# plot(sol)
+
+matrices, _ = get_sensitivity(sys, ap)
+@test matrices.A[] == -2
+@test matrices.B[] * matrices.C[] == -1 # either one negative
+@test matrices.D[] == 1
+
+matrices, _ = get_comp_sensitivity(sys, ap)
+@test matrices.A[] == -2
+@test matrices.B[] * matrices.C[] == 1 # both positive or negative
+@test matrices.D[] == 0
+
+#=
+# Equivalent code using ControlSystems. This can be used to verify the expected results tested for above.
+using ControlSystemsBase
+P = tf(1.0, [1, 1])
+C = 1                      # Negative feedback assumed in ControlSystems
+S = sensitivity(P, C)      # or feedback(1, P*C)
+T = comp_sensitivity(P, C) # or feedback(P*C)
+=#
+
+# Test with automatically created analysis point
+eqs = [connect(P.output, C.input)
+       connect(C.output, :plant_input, P.input)]
+sys = ODESystem(eqs, t, systems = [P, C], name = :hej)
+
+matrices, _ = get_sensitivity(sys, :plant_input)
+@test matrices.A[] == -2
+@test matrices.B[] * matrices.C[] == -1 # either one negative
+@test matrices.D[] == 1
+
+matrices, _ = get_comp_sensitivity(sys, :plant_input)
+@test matrices.A[] == -2
+@test matrices.B[] * matrices.C[] == 1 # both positive
+@test matrices.D[] == 0

--- a/test/Blocks/test_analysis_points.jl
+++ b/test/Blocks/test_analysis_points.jl
@@ -93,3 +93,46 @@ matrices, _ = linearize(sys, :plant_input, :plant_output)
 @test matrices.A[] == -1
 @test matrices.B[] * matrices.C[] == 1 # both positive
 @test matrices.D[] == 0
+
+## Test with subsystems
+
+@named P = FirstOrder(k = 1, T = 1)
+@named C = Gain(1)
+@named add = Blocks.Add(k2 = -1)
+t = ModelingToolkit.get_iv(P)
+
+eqs = [connect(P.output, :plant_output, add.input2)
+       connect(add.output, C.input)
+       connect(C.output, :plant_input, P.input)]
+
+# eqs = [connect(P.output, add.input2)
+#        connect(add.output, C.input)
+#        connect(C.output, P.input)]
+
+sys_inner = ODESystem(eqs, t, systems = [P, C, add], name = :inner)
+
+@named r = Constant(k = 1)
+@named F = FirstOrder(k = 1, T = 3)
+
+eqs = [connect(r.output, F.input)
+       connect(F.output, sys_inner.add.input1)]
+sys_outer = ODESystem(eqs, t, systems = [F, sys_inner, r], name = :outer)
+
+# test first that the structural_simplify ∘ expand_analysis_points works correctly
+ssys = structural_simplify(expand_analysis_points(sys_outer))
+# ssys = structural_simplify((sys_outer))
+prob = ODEProblem(ssys, [P.x => 1], (0, 10))
+# sol = solve(prob, Rodas5())
+# plot(sol)
+
+matrices, _ = get_sensitivity(sys_outer, :inner_plant_input)
+
+using ControlSystemsBase # This is required to simplify the results to test against known solution
+lsys = sminreal(ss(matrices...))
+@test lsys.A[] == -2
+@test lsys.B[] * lsys.C[] == -1 # either one negative
+@test lsys.D[] == 1
+
+matrices_So, _ = get_sensitivity(sys_outer, :inner_plant_output)
+lsyso = sminreal(ss(matrices_So...))
+@test lsys == lsyso || lsys == -1 * lsyso * (-1) # Output and input sensitivites are equal for SISO systems

--- a/test/Mechanical/rotational.jl
+++ b/test/Mechanical/rotational.jl
@@ -60,7 +60,8 @@ end
                                  sine,
                              ])
     sys = structural_simplify(model)
-    prob = DAEProblem(sys, D.(states(sys)) .=> 0.0, [D(D(inertia2.phi)) => 1.0; D.(states(model)) .=> 0.0], (0, 10.0))
+    prob = DAEProblem(sys, D.(states(sys)) .=> 0.0,
+                      [D(D(inertia2.phi)) => 1.0; D.(states(model)) .=> 0.0], (0, 10.0))
     sol = solve(prob, DFBDF())
 
     # Plots.plot(sol; vars=[inertia1.w, -inertia2.w*2])


### PR DESCRIPTION
This PR adds something called an `AnalysisPoint`. These are used for linear analyses, such as 
- Computing sensitivity functions.
- Computing complementary sensitivity functions.
- Computing loop-transfer functions.
- Linearizing systems between predefined analysis points.
- Open loops

An `AnalysisPoint` can be created explicitly, but also automatically when `connect`ing an output to an input. Analysis points are causal, and are thus defined in the `Blocks` submodule. They thus expect connections of type `Blocks.RealInput` and `Blocks.ReaOutput`. 

## Notes to reviewers
- ~The current state of the PR does not handle namespaces and subsystems properly. In particular, I'm unsure about the proper way of modifying equations and namespaces when changing the equations in a system with subsystems.~ Namespaces are now handled.
- The user must currently call `expand_analysis_points` manually before simulating a system containing analysis points. It would be good if this would be handled automatically by `structural_simplify`. The current implementation requires `expand_analysis_points` to run before `expand_connections`, but I could not find a clean way of extending this functionality from outside of ModelingToolkit. One approach would be to define `AnalysisPoint` in MTK, but keep the functions related to sensitivity functions here (they require components from MTKStdlib)
- The last commit depends on the PR below
- https://github.com/SciML/ModelingToolkit.jl/pull/1827