### PR TITLE
remove input annotations on RealInput

### DIFF
--- a/src/Blocks/utils.jl
+++ b/src/Blocks/utils.jl
@@ -1,8 +1,8 @@
 @connector function RealInput(; name, nin = 1, u_start = nin > 1 ? zeros(nin) : 0.0)
     if nin == 1
-        @variables u(t)=u_start [input = true]
+        @variables u(t) = u_start
     else
-        @variables u(t)[1:nin]=u_start [input = true]
+        @variables u(t)[1:nin] = u_start
         u = collect(u)
     end
     ODESystem(Equation[], t, [u...], []; name = name)
@@ -22,9 +22,9 @@ Connector with one input signal of type Real.
 
 @connector function RealOutput(; name, nout = 1, u_start = nout > 1 ? zeros(nout) : 0.0)
     if nout == 1
-        @variables u(t)=u_start [output = true]
+        @variables u(t) = u_start
     else
-        @variables u(t)[1:nout]=u_start [output = true]
+        @variables u(t)[1:nout] = u_start
         u = collect(u)
     end
     ODESystem(Equation[], t, [u...], []; name = name)


### PR DESCRIPTION
This does not work as intended since the annotated variable resides inside a system without internal connections. Until MTK has more formally specified semantics for causal connections, we rely on the explicit passing of input variables to all functions that require it, such as linearize.

@ValentinKaisermayer 

This PR should resolve https://github.com/SciML/ModelingToolkitStandardLibrary.jl/pull/49#discussion_r985133712