### PR TITLE
add descriptions to variables and parameters

### DIFF
--- a/src/Blocks/continuous.jl
+++ b/src/Blocks/continuous.jl
@@ -127,16 +127,15 @@ Critical damping corresponds to `d=1`, which yields the fastest step response wi
 function SecondOrder(; name, k = 1, w, d, x_start = 0.0, xd_start = 0.0)
     @named siso = SISO()
     @unpack u, y = siso
-    sts = @variables x(t)=x_start [description = "State of SecondOrder filter $name"] xd(t)=xd_start [
-        description = "Derivative state of SecondOrder filter $name",
-    ]
-    pars = @parameters k=k [description = "Gain of SecondOrder $name"] w=w [
-        description = "Bandwidth of SecondOrder $name",
-    ] d=d [description = "Relative damping of SecondOrder $name"]
+    @variables x(t)=x_start [description = "State of SecondOrder filter $name"]
+    @variables xd(t)=xd_start [description = "Derivative state of SecondOrder filter $name"]
+    @parameters k=k [description = "Gain of SecondOrder $name"]
+    @parameters w=w [description = "Bandwidth of SecondOrder $name"]
+    @parameters d=d [description = "Relative damping of SecondOrder $name"]
     eqs = [D(x) ~ xd
            D(xd) ~ w * (w * (k * u - x) - 2 * d * xd)
            y ~ x]
-    extend(ODESystem(eqs, t, sts, pars; name = name), siso)
+    extend(ODESystem(eqs, t; name = name), siso)
 end
 
 """

--- a/src/Blocks/continuous.jl
+++ b/src/Blocks/continuous.jl
@@ -127,9 +127,9 @@ Critical damping corresponds to `d=1`, which yields the fastest step response wi
 function SecondOrder(; name, k = 1, w, d, x_start = 0.0, xd_start = 0.0)
     @named siso = SISO()
     @unpack u, y = siso
-    sts = @variables x(t)=x_start [description = "State of SecondOrder filter $name"] function xd(t)
-        xd_start
-    end [description = "Derivative state of SecondOrder filter $name"]
+    sts = @variables x(t)=x_start [description = "State of SecondOrder filter $name"] xd(t)=xd_start [
+        description = "Derivative state of SecondOrder filter $name",
+    ]
     pars = @parameters k=k [description = "Gain of SecondOrder $name"] w=w [
         description = "Bandwidth of SecondOrder $name",
     ] d=d [description = "Relative damping of SecondOrder $name"]

--- a/src/Blocks/continuous.jl
+++ b/src/Blocks/continuous.jl
@@ -14,8 +14,8 @@ Outputs `y = ∫k*u dt`, corresponding to the transfer function `1/s`.
 function Integrator(; name, k = 1, x_start = 0.0)
     @named siso = SISO()
     @unpack u, y = siso
-    sts = @variables x(t) = x_start
-    pars = @parameters k = k
+    sts = @variables x(t)=x_start [description = "State of Integrator $name"]
+    pars = @parameters k=k [description = "Gain of Integrator $name"]
     eqs = [D(x) ~ k * u
            y ~ x]
     extend(ODESystem(eqs, t, sts, pars; name = name), siso)
@@ -49,8 +49,10 @@ function Derivative(; name, k = 1, T, x_start = 0.0)
     T > 0 || throw(ArgumentError("Time constant `T` has to be strictly positive"))
     @named siso = SISO()
     @unpack u, y = siso
-    sts = @variables x(t) = x_start
-    pars = @parameters T=T k=k
+    sts = @variables x(t)=x_start [description = "State of Derivative $name"]
+    pars = @parameters T=T [description = "Time constant of Derivative $name"] k=k [
+        description = "Gain of Derivative $name",
+    ]
     eqs = [D(x) ~ (u - x) / T
            y ~ (k / T) * (u - x)]
     extend(ODESystem(eqs, t, sts, pars; name = name), siso)
@@ -89,8 +91,10 @@ function FirstOrder(; name, k = 1, T, x_start = 0.0, lowpass = true)
     T > 0 || throw(ArgumentError("Time constant `T` has to be strictly positive"))
     @named siso = SISO()
     @unpack u, y = siso
-    sts = @variables x(t) = x_start
-    pars = @parameters T=T k=k
+    sts = @variables x(t)=x_start [description = "State of FirstOrder filter $name"]
+    pars = @parameters T=T [description = "Time constant of FirstOrder filter $name"] k=k [
+        description = "Gain of FirstOrder $name",
+    ]
     eqs = [D(x) ~ (k * u - x) / T
            lowpass ? y ~ x : y ~ k * u - x]
     extend(ODESystem(eqs, t, sts, pars; name = name), siso)
@@ -123,8 +127,12 @@ Critical damping corresponds to `d=1`, which yields the fastest step response wi
 function SecondOrder(; name, k = 1, w, d, x_start = 0.0, xd_start = 0.0)
     @named siso = SISO()
     @unpack u, y = siso
-    sts = @variables x(t)=x_start xd(t)=xd_start
-    pars = @parameters k=k w=w d=d
+    sts = @variables x(t)=x_start [description = "State of SecondOrder filter $name"] function xd(t)
+        xd_start
+    end [description = "Derivative state of SecondOrder filter $name"]
+    pars = @parameters k=k [description = "Gain of SecondOrder $name"] w=w [
+        description = "Bandwidth of SecondOrder $name",
+    ] d=d [description = "Relative damping of SecondOrder $name"]
     eqs = [D(x) ~ xd
            D(xd) ~ w * (w * (k * u - x) - 2 * d * xd)
            y ~ x]
@@ -451,7 +459,9 @@ function StateSpace(; A, B, C, D = nothing, x_start = zeros(size(A, 1)), name,
     end
     @named input = RealInput(nin = nu)
     @named output = RealOutput(nout = ny)
-    @variables x(t)[1:nx] = x_start
+    @variables x(t)[1:nx]=x_start [
+        description = "State variables of StateSpace system $name",
+    ]
     # pars = @parameters A=A B=B C=C D=D # This is buggy
     eqs = [ # FIXME: if array equations work
         [Differential(t)(x[i]) ~ sum(A[i, k] * x[k] for k in 1:nx) +

--- a/src/Blocks/math.jl
+++ b/src/Blocks/math.jl
@@ -13,7 +13,7 @@ Output the product of a gain value with the input signal.
 function Gain(k; name)
     @named siso = SISO()
     @unpack u, y = siso
-    pars = @parameters k = k
+    pars = @parameters k=k [description = "Gain of Gain $name"]
     eqs = [
         y ~ k * u,
     ]
@@ -99,10 +99,8 @@ function Add(; name, k1 = 1, k2 = 1)
     @named input1 = RealInput()
     @named input2 = RealInput()
     @named output = RealOutput()
-    pars = @parameters begin
-        k1 = k1
-        k2 = k2
-    end
+    pars = @parameters(k1=k1, [description = "Gain of Add $name input1"],
+                       k2=k2, [description = "Gain of Add $name input2"],)
     eqs = [
         output.u ~ k1 * input1.u + k2 * input2.u,
     ]
@@ -130,11 +128,9 @@ function Add3(; name, k1 = 1, k2 = 1, k3 = 1)
     @named input2 = RealInput()
     @named input3 = RealInput()
     @named output = RealOutput()
-    pars = @parameters begin
-        k1 = k1
-        k2 = k2
-        k3 = k3
-    end
+    pars = @parameters(k1=k1, [description = "Gain of Add $name input1"],
+                       k2=k2, [description = "Gain of Add $name input2"],
+                       k3=k3, [description = "Gain of Add $name input3"],)
     eqs = [
         output.u ~ k1 * input1.u + k2 * input2.u + k3 * input3.u,
     ]

--- a/src/Blocks/nonlinear.jl
+++ b/src/Blocks/nonlinear.jl
@@ -18,7 +18,9 @@ function Limiter(; name, y_max, y_min = y_max > 0 ? -y_max : -Inf)
     y_max ≥ y_min || throw(ArgumentError("`y_min` must be smaller than `y_max`"))
     @named siso = SISO()
     @unpack u, y = siso
-    pars = @parameters y_max=y_max y_min=y_min
+    pars = @parameters y_max=y_max [description = "Maximum allowed output of Limiter $name"] y_min=y_min [
+        description = "Minimum allowed output of Limiter $name",
+    ]
     eqs = [
         y ~ _clamp(u, y_min, y_max),
     ]
@@ -55,7 +57,9 @@ function DeadZone(; name, u_max, u_min = -u_max)
     end
     @named siso = SISO()
     @unpack u, y = siso
-    pars = @parameters u_max=u_max u_min=u_min
+    pars = @parameters u_max=u_max [
+        description = "Upper limit of dead zone of DeadZone $name",
+    ] u_min=u_min [description = "Lower limit of dead zone of DeadZone $name"]
     eqs = [
         y ~ _dead_zone(u, u_min, u_max),
     ]
@@ -81,7 +85,11 @@ function SlewRateLimiter(; name, rising = 1, falling = -rising, Td = 0.001, y_st
     Td > 0 || throw(ArgumentError("Time constant `Td` must be strictly positive"))
     @named siso = SISO(y_start = y_start)
     @unpack u, y = siso
-    pars = @parameters rising=rising falling=falling
+    pars = @parameters rising=rising [
+        description = "Maximum rising slew rate of SlewRateLimiter $name",
+    ] falling=falling [description = "Maximum falling slew rate of SlewRateLimiter $name"] Td=Td [
+        description = "Derivative time constant of SlewRateLimiter $name",
+    ]
     eqs = [
         D(y) ~ max(min((u - y) / Td, rising), falling),
     ]

--- a/src/Blocks/sources.jl
+++ b/src/Blocks/sources.jl
@@ -69,7 +69,7 @@ Generate constant signal.
 """
 function Constant(; name, k = 1)
     @named output = RealOutput()
-    pars = @parameters k = k
+    pars = @parameters k=k [description = "Constant output value of block $name"]
     eqs = [
         output.u ~ k,
     ]

--- a/src/Blocks/utils.jl
+++ b/src/Blocks/utils.jl
@@ -1,8 +1,14 @@
 @connector function RealInput(; name, nin = 1, u_start = nin > 1 ? zeros(nin) : 0.0)
     if nin == 1
-        @variables u(t)=u_start [input = true]
+        @variables u(t)=u_start [
+            input = true,
+            description = "Inner variable in RealInput $name",
+        ]
     else
-        @variables u(t)[1:nin]=u_start [input = true]
+        @variables u(t)[1:nin]=u_start [
+            input = true,
+            description = "Inner variable in RealInput $name",
+        ]
         u = collect(u)
     end
     ODESystem(Equation[], t, [u...], []; name = name)
@@ -22,9 +28,15 @@ Connector with one input signal of type Real.
 
 @connector function RealOutput(; name, nout = 1, u_start = nout > 1 ? zeros(nout) : 0.0)
     if nout == 1
-        @variables u(t)=u_start [output = true]
+        @variables u(t)=u_start [
+            output = true,
+            description = "Inner variable in RealOutput $name",
+        ]
     else
-        @variables u(t)[1:nout]=u_start [output = true]
+        @variables u(t)[1:nout]=u_start [
+            output = true,
+            description = "Inner variable in RealOutput $name",
+        ]
         u = collect(u)
     end
     ODESystem(Equation[], t, [u...], []; name = name)
@@ -54,10 +66,8 @@ Single input single output (SISO) continuous system block.
 function SISO(; name, u_start = 0.0, y_start = 0.0)
     @named input = RealInput(u_start = u_start)
     @named output = RealOutput(u_start = y_start)
-    @variables begin
-        u(t) = u_start
-        y(t) = y_start
-    end
+    @variables(u(t)=u_start, [description = "Input of SISO system $name"],
+               y(t)=y_start, [description = "Output of SISO system $name"],)
     eqs = [u ~ input.u
            y ~ output.u]
     return ODESystem(eqs, t, [u, y], []; name = name, systems = [input, output])
@@ -77,10 +87,8 @@ Base class for a multiple input multiple output (MIMO) continuous system block.
 function MIMO(; name, nin = 1, nout = 1, u_start = zeros(nin), y_start = zeros(nout))
     @named input = RealInput(nin = nin, u_start = u_start)
     @named output = RealOutput(nout = nout, u_start = y_start)
-    @variables begin
-        u(t)[1:nin] = u_start
-        y(t)[1:nout] = y_start
-    end
+    @variables(u(t)[1:nin]=u_start, [description = "Input of MIMO system $name"],
+               y(t)[1:nout]=y_start, [description = "Output of MIMO system $name"],)
     eqs = [
         [u[i] ~ input.u[i] for i in 1:nin]...,
         [y[i] ~ output.u[i] for i in 1:nout]...,

--- a/src/Mechanical/Rotational/utils.jl
+++ b/src/Mechanical/Rotational/utils.jl
@@ -1,8 +1,6 @@
 @connector function Flange(; name)
-    sts = @variables begin
-        phi(t)
-        tau(t), [connect = Flow]
-    end
+    sts = @variables(phi(t), [description = "Rotation angle of flange $name"],
+                     tau(t), [connect = Flow, description = "Cut torque in flange $name"],)
     ODESystem(Equation[], t, sts, [], name = name, defaults = Dict(phi => 0.0, tau => 0.0))
 end
 Base.@doc """
@@ -16,10 +14,8 @@ Base.@doc """
 """ Flange
 
 @connector function Support(; name)
-    sts = @variables begin
-        phi(t)
-        tau(t), [connect = Flow]
-    end
+    sts = @variables(phi(t), [description = "Rotation angle of support $name"],
+                     tau(t), [connect = Flow, description = "Cut torque in support $name"],)
     ODESystem(Equation[], t, sts, [], name = name, defaults = Dict(phi => 0.0, tau => 0.0))
 end
 Base.@doc """
@@ -52,10 +48,9 @@ Partial model for the compliant connection of two rotational 1-dim. shaft flange
 function PartialCompliant(; name, phi_rel_start = 0.0, tau_start = 0.0)
     @named flange_a = Flange()
     @named flange_b = Flange()
-    sts = @variables begin
-        phi_rel(t) = phi_rel_start
-        tau(t) = tau_start
-    end
+    sts = @variables(phi_rel(t)=phi_rel_start,
+                     [description = "Relative rotation angle between flanges"],
+                     tau(t)=tau_start, [description = "Torque between flanges"])
     eqs = [phi_rel ~ flange_b.phi - flange_a.phi
            flange_b.tau ~ tau
            flange_a.tau ~ -tau]
@@ -87,12 +82,13 @@ function PartialCompliantWithRelativeStates(; name, phi_rel_start = 0.0, w_start
                                             a_start = 0.0, tau_start = 0.0)
     @named flange_a = Flange()
     @named flange_b = Flange()
-    sts = @variables begin
-        phi_rel(t) = phi_rel_start
-        w_rel(t) = w_start
-        a_rel(t) = a_start
-        tau(t) = tau_start
-    end
+    sts = @variables(phi_rel(t)=phi_rel_start,
+                     [description = "Relative rotation angle between flanges"],
+                     w_rel(t)=w_start,
+                     [description = "Relative angular velocity between flanges"],
+                     a_rel(t)=a_start,
+                     [description = "Relative angular acceleration between flanges"],
+                     tau(t)=tau_start, [description = "Torque between flanges"],)
     eqs = [phi_rel ~ flange_b.phi - flange_a.phi
            D(phi_rel) ~ w_rel
            D(w_rel) ~ a_rel
@@ -118,7 +114,7 @@ Partial model for a component with one rotational 1-dim. shaft flange and a supp
 function PartialElementaryOneFlangeAndSupport2(; name, use_support = false)
     @named flange = Flange()
     sys = [flange]
-    @variables phi_support(t) = 0.0
+    @variables phi_support(t)=0.0 [description = "Absolute angle of support flange"]
     if use_support
         @named support = Support()
         eqs = [support.phi ~ phi_support
@@ -150,7 +146,7 @@ function PartialElementaryTwoFlangesAndSupport2(; name, use_support = false)
     @named flange_a = Flange()
     @named flange_b = Flange()
     sys = [flange_a, flange_b]
-    @variables phi_support(t) = 0.0
+    @variables phi_support(t)=0.0 [description = "Absolute angle of support flange"]
     if use_support
         @named support = Support()
         eqs = [support.phi ~ phi_support


### PR DESCRIPTION
This PR adds `[description = "sting"]` to a number of variables and parameters in the Blocks and Rotational modules. Other modules will come in separate PRs.

This serves two purposes
1. Make models from model libraries easier to work with. Without a description, it's hard to know what a variable called `k` deep inside a model does, in particular if the model comes from a library.
2. Illustrate best practices. People are likely to look to MTKstdlib to learn how to build component libraries, and I hope to establish adding variable descriptions as a best practice people follow. 