### PR TITLE
Digital: Adds `Logic` and defines 9 logic levels, `StdULogicVector`, and `StdLogicVector`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,13 +7,11 @@ version = "1.11.0"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
-OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 IfElse = "0.1"
 ModelingToolkit = "8.26"
-OffsetArrays = "1"
 Symbolics = "4.9, 5"
 julia = "1.6"
 

--- a/src/Electrical/Digital/logic.jl
+++ b/src/Electrical/Digital/logic.jl
@@ -1,0 +1,68 @@
+struct Logic
+    level::Int
+end
+
+function Base.show(io::IO, ::MIME"text/plain", l::Logic)
+    if l.level == 1
+        print(io, "U")
+    elseif l.level == 2
+        print(io, "X")
+    elseif l.level == 3
+        print(io, "F0")
+    elseif l.level == 4
+        print(io, "F1")
+    elseif l.level == 5
+        print(io, "Z")
+    elseif l.level == 6
+        print(io, "W")
+    elseif l.level == 7
+        print(io, "L")
+    elseif l.level == 8
+        print(io, "H")
+    elseif l.level == 9
+        print(io, "DC")
+    else
+        print(io, "Invalid logic level")
+    end
+end
+
+# Aliases for 9 Digital Logic levels
+const Uninitialized = Logic(1)
+const ForcingUnknown = Logic(2)
+const ForcingZero = Logic(3)
+const ForcingOne = Logic(4)
+const HighImpedence = Logic(5)
+const WeakUnknown = Logic(6)
+const WeakZero = Logic(7)
+const WeakOne = Logic(8)
+const DontCare = Logic(9)
+
+const U = Uninitialized
+const X = ForcingUnknown
+const F0 = ForcingZero
+const F1 = ForcingOne
+const Z = HighImpedence
+const W = WeakUnknown
+const L = WeakZero
+const H = WeakOne
+const DC = DontCare
+
+Base.zero(l::Logic) = F0
+Base.zero(l::Type{Logic}) = F0
+Base.one(l::Logic) = F1
+Base.one(l::Type{Logic}) = F1
+
+# Helpers to convert 1 and 0 to their `Logic` counterparts
+function Base.convert(l::Type{Logic}, i::Number)
+    if i == zero(i)
+        zero(l)
+    elseif i == one(i)
+        one(l)
+    else
+        throw("This isn't a valid `Logic` value")
+    end
+end
+Base.convert(l::Type{Logic}, i::Logic) = i
+
+convert_to_logic(i::Number) = convert(Logic, i)
+convert_to_logic(i::Logic) = i

--- a/src/Electrical/Digital/logic.jl
+++ b/src/Electrical/Digital/logic.jl
@@ -30,14 +30,14 @@ function Base.show(io::IO, ::MIME"text/plain", l::Logic)
     elseif Int(l) == 9
         print(io, "DC")
     else
-        print(io, "Invalid logic level")
+        print(io, "Invalid logic level: $l")
     end
 end
 
-Base.zero(l::Logic) = F0
-Base.zero(l::Type{Logic}) = F0
-Base.one(l::Logic) = F1
-Base.one(l::Type{Logic}) = F1
+Base.zero(::Logic) = F0
+Base.zero(::Type{Logic}) = F0
+Base.one(::Logic) = F1
+Base.one(::Type{Logic}) = F1
 
 # Helpers to convert 1 and 0 to their `Logic` counterparts
 function Base.convert(l::Type{Logic}, i::Number)

--- a/src/Electrical/Digital/logic.jl
+++ b/src/Electrical/Digital/logic.jl
@@ -1,41 +1,4 @@
-struct Logic
-    level::Int
-end
-
-function Base.show(io::IO, ::MIME"text/plain", l::Logic)
-    if l.level == 1
-        print(io, "U")
-    elseif l.level == 2
-        print(io, "X")
-    elseif l.level == 3
-        print(io, "F0")
-    elseif l.level == 4
-        print(io, "F1")
-    elseif l.level == 5
-        print(io, "Z")
-    elseif l.level == 6
-        print(io, "W")
-    elseif l.level == 7
-        print(io, "L")
-    elseif l.level == 8
-        print(io, "H")
-    elseif l.level == 9
-        print(io, "DC")
-    else
-        print(io, "Invalid logic level")
-    end
-end
-
-# Aliases for 9 Digital Logic levels
-const Uninitialized = Logic(1)
-const ForcingUnknown = Logic(2)
-const ForcingZero = Logic(3)
-const ForcingOne = Logic(4)
-const HighImpedence = Logic(5)
-const WeakUnknown = Logic(6)
-const WeakZero = Logic(7)
-const WeakOne = Logic(8)
-const DontCare = Logic(9)
+@enum Logic Uninitialized=1 ForcingUnknown ForcingZero ForcingOne HighImpedence WeakUnknown WeakZero WeakOne DontCare
 
 const U = Uninitialized
 const X = ForcingUnknown
@@ -46,6 +9,30 @@ const W = WeakUnknown
 const L = WeakZero
 const H = WeakOne
 const DC = DontCare
+
+function Base.show(io::IO, ::MIME"text/plain", l::Logic)
+    if Int(l) == 1
+        print(io, "U")
+    elseif Int(l) == 2
+        print(io, "X")
+    elseif Int(l) == 3
+        print(io, "F0")
+    elseif Int(l) == 4
+        print(io, "F1")
+    elseif Int(l) == 5
+        print(io, "Z")
+    elseif Int(l) == 6
+        print(io, "W")
+    elseif Int(l) == 7
+        print(io, "L")
+    elseif Int(l) == 8
+        print(io, "H")
+    elseif Int(l) == 9
+        print(io, "DC")
+    else
+        print(io, "Invalid logic level")
+    end
+end
 
 Base.zero(l::Logic) = F0
 Base.zero(l::Type{Logic}) = F0
@@ -59,10 +46,9 @@ function Base.convert(l::Type{Logic}, i::Number)
     elseif i == one(i)
         one(l)
     else
-        throw("This isn't a valid `Logic` value")
+        throw("$i isn't a valid `Logic` value")
     end
 end
 Base.convert(l::Type{Logic}, i::Logic) = i
 
-convert_to_logic(i::Number) = convert(Logic, i)
-convert_to_logic(i::Logic) = i
+get_logic_level(l::Logic) = Int(l)

--- a/src/Electrical/Digital/logic_vectors.jl
+++ b/src/Electrical/Digital/logic_vectors.jl
@@ -5,42 +5,41 @@ const LogicOrNumber = Union{Logic, Number}
 struct StdULogicVector{N} <: AbstractArray{Logic, N}
     logic::AbstractArray{Logic}
     level::AbstractArray{Int}
-    function StdULogicVector(l::AbstractArray{<:LogicOrNumber})
+    function StdULogicVector(l::AbstractArray)
         N = ndims(l)
         l = AbstractArray{Logic}(convert.(Logic, l))
-        levels = get_logic_level.(l)
-        new{N}(l, levels)
+        new{N}(l, get_logic_level.(l))
     end
 end
 
 struct StdLogicVector{N} <: AbstractArray{Logic, N}
     logic::AbstractArray{Logic}
     level::AbstractArray{Int}
-    function StdLogicVector(l::AbstractArray{<:LogicOrNumber})
+    function StdLogicVector(l::AbstractArray)
         N = ndims(l)
         l = AbstractArray{Logic}(convert.(Logic, l))
-        levels = get_logic_level.(l)
-        new{N}(l, levels)
+        new{N}(l, get_logic_level.(l))
     end
 end
 
-Base.size(l::T) where {T <: Union{StdULogicVector, StdLogicVector}} = size(l.logic)
+const LogicVector = Union{StdULogicVector, StdLogicVector}
 
-Base.axes(l::T) where {T <: Union{StdULogicVector, StdLogicVector}} = axes(l.logic)
+Base.size(l::L) where {L <: LogicVector} = size(l.logic)
 
-function Base.getindex(s::T,
-                       i::Int) where {T <: Union{StdULogicVector{N}, StdLogicVector{N}}
-                                      } where {N}
+Base.axes(l::L) where {L <: LogicVector} = axes(l.logic)
+
+function Base.getindex(s::L,
+                       i::Int) where {L <: LogicVector}
     getindex(s.logic, i)
 end
-function Base.getindex(s::T, i1::Int, i2::Int,
-                       I::Int...) where {T <: Union{StdULogicVector{N}, StdLogicVector{N}}
-                                         } where {N}
+function Base.getindex(s::L, i1::Int, i2::Int,
+                       I::Int...) where {L <: LogicVector}
     getindex(s.logic, i1, i2, I...)
 end
 
-# predefined vectors
+get_logic_level(s::L) where {L <: LogicVector} = s.level
 
+# predefined vectors
 std_ulogic = StdULogicVector([U, X, F0, F1, Z, W, L, H, DC])
 UX01 = StdULogicVector([U, X, F0, F1])
 UX01Z = StdULogicVector([U, X, F0, F1, Z])

--- a/src/Electrical/Digital/logic_vectors.jl
+++ b/src/Electrical/Digital/logic_vectors.jl
@@ -1,23 +1,23 @@
-import Base: size, axes, getindex
+import Base: size, axes, getindex, setindex!
 
 const LogicOrNumber = Union{Logic, Number}
 
 struct StdULogicVector{N} <: AbstractArray{Logic, N}
-    logic::AbstractArray{Logic}
-    level::AbstractArray{Int}
-    function StdULogicVector(l::AbstractArray)
+    logic::Array{Logic, N}
+    level::Array{Int, N}
+    function StdULogicVector(l::Array)
         N = ndims(l)
-        l = AbstractArray{Logic}(convert.(Logic, l))
+        l = Array{Logic}(convert.(Logic, l))
         new{N}(l, get_logic_level.(l))
     end
 end
 
 struct StdLogicVector{N} <: AbstractArray{Logic, N}
-    logic::AbstractArray{Logic}
-    level::AbstractArray{Int}
-    function StdLogicVector(l::AbstractArray)
+    logic::Array{Logic, N}
+    level::Array{Int, N}
+    function StdLogicVector(l::Array)
         N = ndims(l)
-        l = AbstractArray{Logic}(convert.(Logic, l))
+        l = Array{Logic}(convert.(Logic, l))
         new{N}(l, get_logic_level.(l))
     end
 end
@@ -37,11 +37,21 @@ function Base.getindex(s::LogicVector, i1::Int, i2::Int,
     getindex(s.logic, i1, i2, I...)
 end
 
+function Base.setindex!(A::LogicVector, x::Logic, i1::Int)
+    setindex!(A.logic, x, i1)
+    setindex!(A.level, get_logic_level(x), i1)
+end
+
+function Base.setindex!(A::LogicVector, x::Logic, i1::Int, i2::Int, I::Int...)
+    setindex!(A.logic, x, i1, i2, I...)
+    setindex!(A.level, get_logic_level(x), i1, i2, I...)
+end
+
 get_logic_level(s::LogicVector) = s.level
 
 # predefined vectors
-std_ulogic = StdULogicVector([U, X, F0, F1, Z, W, L, H, DC])
-UX01 = StdULogicVector([U, X, F0, F1])
-UX01Z = StdULogicVector([U, X, F0, F1, Z])
-X01 = StdULogicVector([X, F0, F1])
-X01Z = StdULogicVector([X, F0, F1, Z])
+const std_ulogic = StdULogicVector([U, X, F0, F1, Z, W, L, H, DC])
+const UX01 = StdULogicVector([U, X, F0, F1])
+const UX01Z = StdULogicVector([U, X, F0, F1, Z])
+const X01 = StdULogicVector([X, F0, F1])
+const X01Z = StdULogicVector([X, F0, F1, Z])

--- a/src/Electrical/Digital/logic_vectors.jl
+++ b/src/Electrical/Digital/logic_vectors.jl
@@ -8,7 +8,7 @@ struct StdULogicVector{N} <: AbstractArray{Logic, N}
     function StdULogicVector(l::AbstractArray{<:LogicOrNumber})
         N = ndims(l)
         l = AbstractArray{Logic}(convert.(Logic, l))
-        levels = getfield.(l, :level)
+        levels = get_logic_level.(l)
         new{N}(l, levels)
     end
 end
@@ -19,7 +19,7 @@ struct StdLogicVector{N} <: AbstractArray{Logic, N}
     function StdLogicVector(l::AbstractArray{<:LogicOrNumber})
         N = ndims(l)
         l = AbstractArray{Logic}(convert.(Logic, l))
-        levels = getfield.(l, :level)
+        levels = get_logic_level.(l)
         new{N}(l, levels)
     end
 end

--- a/src/Electrical/Digital/logic_vectors.jl
+++ b/src/Electrical/Digital/logic_vectors.jl
@@ -24,20 +24,20 @@ end
 
 const LogicVector = Union{StdULogicVector, StdLogicVector}
 
-Base.size(l::L) where {L <: LogicVector} = size(l.logic)
+Base.size(l::LogicVector) = size(l.logic)
 
-Base.axes(l::L) where {L <: LogicVector} = axes(l.logic)
+Base.axes(l::LogicVector) = axes(l.logic)
 
-function Base.getindex(s::L,
-                       i::Int) where {L <: LogicVector}
+function Base.getindex(s::LogicVector,
+                       i::Int)
     getindex(s.logic, i)
 end
-function Base.getindex(s::L, i1::Int, i2::Int,
-                       I::Int...) where {L <: LogicVector}
+function Base.getindex(s::LogicVector, i1::Int, i2::Int,
+                       I::Int...)
     getindex(s.logic, i1, i2, I...)
 end
 
-get_logic_level(s::L) where {L <: LogicVector} = s.level
+get_logic_level(s::LogicVector) = s.level
 
 # predefined vectors
 std_ulogic = StdULogicVector([U, X, F0, F1, Z, W, L, H, DC])

--- a/src/Electrical/Digital/logic_vectors.jl
+++ b/src/Electrical/Digital/logic_vectors.jl
@@ -4,50 +4,36 @@ const LogicOrNumber = Union{Logic, Number}
 
 struct StdULogicVector{N} <: AbstractArray{Logic, N}
     logic::Array{Logic, N}
-    level::Array{Int, N}
     function StdULogicVector(l::Array)
-        N = ndims(l)
-        l = Array{Logic}(convert.(Logic, l))
-        new{N}(l, get_logic_level.(l))
+        new{ndims(l)}(Array{Logic}(convert.(Logic, l)))
     end
 end
 
 struct StdLogicVector{N} <: AbstractArray{Logic, N}
     logic::Array{Logic, N}
-    level::Array{Int, N}
     function StdLogicVector(l::Array)
-        N = ndims(l)
-        l = Array{Logic}(convert.(Logic, l))
-        new{N}(l, get_logic_level.(l))
+        new{ndims(l)}(Array{Logic}(convert.(Logic, l)))
     end
 end
 
 const LogicVector = Union{StdULogicVector, StdLogicVector}
 
-Base.size(l::LogicVector) = size(l.logic)
+size(l::LogicVector) = size(l.logic)
 
-Base.axes(l::LogicVector) = axes(l.logic)
+axes(l::LogicVector) = axes(l.logic)
 
-function Base.getindex(s::LogicVector,
-                       i::Int)
-    getindex(s.logic, i)
-end
+getindex(s::LogicVector, i::Int) = getindex(s.logic, i)
 function Base.getindex(s::LogicVector, i1::Int, i2::Int,
                        I::Int...)
     getindex(s.logic, i1, i2, I...)
 end
 
-function Base.setindex!(A::LogicVector, x::Logic, i1::Int)
-    setindex!(A.logic, x, i1)
-    setindex!(A.level, get_logic_level(x), i1)
-end
-
+setindex!(A::LogicVector, x::Logic, i1::Int) = setindex!(A.logic, x, i1)
 function Base.setindex!(A::LogicVector, x::Logic, i1::Int, i2::Int, I::Int...)
     setindex!(A.logic, x, i1, i2, I...)
-    setindex!(A.level, get_logic_level(x), i1, i2, I...)
 end
 
-get_logic_level(s::LogicVector) = s.level
+get_logic_level(s::LogicVector) = Int.(s.logic)
 
 # predefined vectors
 const std_ulogic = StdULogicVector([U, X, F0, F1, Z, W, L, H, DC])

--- a/src/Electrical/Digital/logic_vectors.jl
+++ b/src/Electrical/Digital/logic_vectors.jl
@@ -1,0 +1,40 @@
+import Base: size, axes, getindex
+
+const LogicOrNumber = Union{Logic, Number}
+
+struct StdULogicVector{N} <: AbstractArray{Logic, N}
+    logic::AbstractArray{Logic}
+    level::AbstractArray{Int}
+    function StdULogicVector(l::AbstractArray{<:LogicOrNumber})
+        N = ndims(l)
+        l = AbstractArray{Logic}(convert.(Logic, l))
+        levels = getfield.(l, :level)
+        new{N}(l, levels)
+    end
+end
+
+struct StdLogicVector{N} <: AbstractArray{Logic, N}
+    logic::AbstractArray{Logic}
+    level::AbstractArray{Int}
+    function StdLogicVector(l::AbstractArray{<:LogicOrNumber})
+        N = ndims(l)
+        l = AbstractArray{Logic}(convert.(Logic, l))
+        levels = getfield.(l, :level)
+        new{N}(l, levels)
+    end
+end
+
+Base.size(l::T) where {T <: Union{StdULogicVector, StdLogicVector}} = size(l.logic)
+
+Base.axes(l::T) where {T <: Union{StdULogicVector, StdLogicVector}} = axes(l.logic)
+
+function Base.getindex(s::T,
+                       i::Int) where {T <: Union{StdULogicVector{N}, StdLogicVector{N}}
+                                      } where {N}
+    getindex(s.logic, i)
+end
+function Base.getindex(s::T, i1::Int, i2::Int,
+                       I::Int...) where {T <: Union{StdULogicVector{N}, StdLogicVector{N}}
+                                         } where {N}
+    getindex(s.logic, i1, i2, I...)
+end

--- a/src/Electrical/Digital/logic_vectors.jl
+++ b/src/Electrical/Digital/logic_vectors.jl
@@ -38,3 +38,11 @@ function Base.getindex(s::T, i1::Int, i2::Int,
                                          } where {N}
     getindex(s.logic, i1, i2, I...)
 end
+
+# predefined vectors
+
+std_ulogic = StdULogicVector([U, X, F0, F1, Z, W, L, H, DC])
+UX01 = StdULogicVector([U, X, F0, F1])
+UX01Z = StdULogicVector([U, X, F0, F1, Z])
+X01 = StdULogicVector([X, F0, F1])
+X01Z = StdULogicVector([X, F0, F1, Z])

--- a/src/Electrical/Digital/tables.jl
+++ b/src/Electrical/Digital/tables.jl
@@ -1,59 +1,97 @@
 # AND gate
-AndTable = [
-            # U X F0 F1 Z W L H DC
-            U U F0 U U U F0 U U        # U
-            U X F0 X X X F0 X X        # X
-            F0 F0 F0 F0 F0 F0 F0 F0 F0 # F0
-            U X F0 F1 X X F0 F1 X      # F1
-            U X F0 X X X F0 X X        # Z
-            U X F0 X X X F0 X X        # W
-            F0 F0 F0 F0 F0 F0 F0 F0 F0 # L
-            U X F0 F1 X X F0 F1 X      # H
-            U X F0 X X X F0 X X]       # DC
+const AndTable = [
+                  # U X F0 F1 Z W L H DC
+                  U U F0 U U U F0 U U        # U
+                  U X F0 X X X F0 X X        # X
+                  F0 F0 F0 F0 F0 F0 F0 F0 F0 # F0
+                  U X F0 F1 X X F0 F1 X      # F1
+                  U X F0 X X X F0 X X        # Z
+                  U X F0 X X X F0 X X        # W
+                  F0 F0 F0 F0 F0 F0 F0 F0 F0 # L
+                  U X F0 F1 X X F0 F1 X      # H
+                  U X F0 X X X F0 X X]       # DC
+
+function _and2(a::Logic, b::Logic)
+    AndTable[a.level, b.level]
+end
+_and2(a::Number, b::Logic) = _and2(convert(Logic, a), b)
+_and2(a::Logic, b::Number) = _and2(a, convert(Logic, b))
+_and2(a::Number, b::Number) = _and2(convert(Logic, a), convert(Logic, b))
+
+function _and(x...)
+    y = x[1]
+    for i in 2:lastindex(x)
+        y = _and2(y, x[i])
+    end
+    return y
+end
+
+@register_symbolic _and(a, b)
 
 # NOT gate
-NotTable = [U, X, F1, F0, X, X, F1, F0, X]
+const NotTable = [U, X, F1, F0, X, X, F1, F0, X]
+
+_not(x::Logic) = NotTable[get_logic_level(x)]
+_not(x::Number) = _not(convert(Logic, x))
+
+@register_symbolic _not(x)
 
 # OR gate
-OrTable = [
-           # U X F0 F1 Z W L H DC
-           U U U F1 U U U F1 U        # U
-           U X X F1 X X X F1 X        # X
-           U X F0 F1 X X F0 F1 X      # F0
-           F1 F1 F1 F1 F1 F1 F1 F1 F1 # F1
-           U X X F1 X X X F1 X        # Z
-           U X X F1 X X X F1 X        # W
-           U X F0 F1 X X F0 F1 X      # L
-           F1 F1 F1 F1 F1 F1 F1 F1 F1 # H
-           U X X F1 X X X F1 X]       # DC
+const OrTable = [
+                 # U X F0 F1 Z W L H DC
+                 U U U F1 U U U F1 U        # U
+                 U X X F1 X X X F1 X        # X
+                 U X F0 F1 X X F0 F1 X      # F0
+                 F1 F1 F1 F1 F1 F1 F1 F1 F1 # F1
+                 U X X F1 X X X F1 X        # Z
+                 U X X F1 X X X F1 X        # W
+                 U X F0 F1 X X F0 F1 X      # L
+                 F1 F1 F1 F1 F1 F1 F1 F1 F1 # H
+                 U X X F1 X X X F1 X]       # DC
+
+function _or2(a::Logic, b::Logic)
+    OrTable[a.level, b.level]
+end
+_or2(a::Number, b::Logic) = _or2(convert(Logic, a), b)
+_or2(a::Logic, b::Number) = _or2(a, convert(Logic, b))
+_or2(a::Number, b::Number) = _or2(convert(Logic, a), convert(Logic, b))
+
+function _or(x...)
+    y = x[1]
+    for i in 2:lastindex(x)
+        y = _or2(y, x[i])
+    end
+    return y
+end
+
+@register_symbolic _or(a, b)
 
 # XOR gate
-XorTable = [
-            # U X F0 F1 Z W L H DC
-            U U U U U U U U U     # U
-            U X X X X X X X X     # X
-            U X F0 F1 X X F0 F1 X # F0
-            U X F1 F0 X X F1 F0 X # F1
-            U X X X X X X X X     # Z
-            U X X X X X X X X     # W
-            U X F0 F1 X X F0 F1 X # L
-            U X F1 F0 X X F1 F0 X # H
-            U X X X X X X X X]    # DC
+const XorTable = [
+                  # U X F0 F1 Z W L H DC
+                  U U U U U U U U U     # U
+                  U X X X X X X X X     # X
+                  U X F0 F1 X X F0 F1 X # F0
+                  U X F1 F0 X X F1 F0 X # F1
+                  U X X X X X X X X     # Z
+                  U X X X X X X X X     # W
+                  U X F0 F1 X X F0 F1 X # L
+                  U X F1 F0 X X F1 F0 X # H
+                  U X X X X X X X X]    # DC
 
-function _xor2(a, b)
-    XorTable[logic_level_dict[a], logic_level_dict[b]]
+function _xor2(a::Logic, b::Logic)
+    XorTable[a.level, b.level]
 end
+_xor2(a::Number, b::Logic) = _xor2(convert(Logic, a), b)
+_xor2(a::Logic, b::Number) = _xor2(a, convert(Logic, b))
+_xor2(a::Number, b::Number) = _xor2(convert(Logic, a), convert(Logic, b))
 
 function _xor(x...)
-    y = [x[1]]
+    y = x[1]
     for i in 2:lastindex(x)
-        push!(y, _xor2(x[i], y[i - 1]))
+        y = _xor2(y, x[i])
     end
-    return y[end]
+    return y
 end
 
-@register_symbolic _xor(x...)
 @register_symbolic _xor(a, b)
-@register_symbolic _xor(a, b, c)
-@register_symbolic _xor(a, b, c, d)
-@register_symbolic _xor(a, b, c, d, e)

--- a/src/Electrical/Digital/tables.jl
+++ b/src/Electrical/Digital/tables.jl
@@ -1,131 +1,59 @@
-# 9-level logic
-@parameters X
+# AND gate
+AndTable = [
+            # U X F0 F1 Z W L H DC
+            U U F0 U U U F0 U U        # U
+            U X F0 X X X F0 X X        # X
+            F0 F0 F0 F0 F0 F0 F0 F0 F0 # F0
+            U X F0 F1 X X F0 F1 X      # F1
+            U X F0 X X X F0 X X        # Z
+            U X F0 X X X F0 X X        # W
+            F0 F0 F0 F0 F0 F0 F0 F0 F0 # L
+            U X F0 F1 X X F0 F1 X      # H
+            U X F0 X X X F0 X X]       # DC
 
-logicmap = Dict(0 => 0,
-                1 => 1,
-                :U => 2, # Uninitialized
-                :X => 3, # Unknown
-                :Z => 4, # High Impedence
-                :W => 5, # Weak Unknown
-                :L => 6, # Weak Low
-                :H => 7, # Weak High
-                :D => 8) # Don't Care; standard representation is `-`
+# NOT gate
+NotTable = [U, X, F1, F0, X, X, F1, F0, X]
 
-logic(l) =
-    try
-        logicmap[l]
-    catch
-        (ex)
-        X
-    end
+# OR gate
+OrTable = [
+           # U X F0 F1 Z W L H DC
+           U U U F1 U U U F1 U        # U
+           U X X F1 X X X F1 X        # X
+           U X F0 F1 X X F0 F1 X      # F0
+           F1 F1 F1 F1 F1 F1 F1 F1 F1 # F1
+           U X X F1 X X X F1 X        # Z
+           U X X F1 X X X F1 X        # W
+           U X F0 F1 X X F0 F1 X      # L
+           F1 F1 F1 F1 F1 F1 F1 F1 F1 # H
+           U X X F1 X X X F1 X]       # DC
 
-# SISO NOT gate
-NotTable = OffsetArray([
-                        # 0  1  :U  :X  :Z  :W  :L  :H  :D
-                        1; 0; :U; :X; :X; :X; 1; 0; :X], 0:8)
-
-function _not(x)
-    i = logic(x)
-    typeof(i) != Int && return X
-    NotTable[i]
-end
-@register_symbolic _not(x)
-
-# MISO AND gate
-AndTable = OffsetArray([
-                        # 0  1 :U :X :Z :W :L :H :D
-                        0 0 0 0 0 0 0 0 0 # 0
-                        0 1 :U :X :X :X 0 1 :X # 1
-                        0 :U :U :U :U :U 0 :U :U # :U
-                        0 :X :U :X :X :X 0 :X :X # :X
-                        0 :X :U :X :X :X 0 :X :X # :Z
-                        0 1 :U :X :X :X 0 :X :X # :W
-                        0 0 0 0 0 0 0 0 0 # :L
-                        0 1 :U :X :X :X 0 1 :X # :H
-                        0 :X :U :X :X :X 0 :X :X], 0:8, 0:8)
-
-function _and2(a, b)
-    i, j = logic(a), logic(b)
-    (typeof(i) != Int || typeof(j) != Int) && return X
-    AndTable[i, j]
-end
-function _and(x...)
-    y = [_and2(x[1], x[1])]
-    for i in 2:length(x)
-        push!(y, _and2(x[i], y[i - 1]))
-    end
-    return y[end]
-end
-@register_symbolic _and(x...)
-@register_symbolic _and(a, b)
-@register_symbolic _and(a, b, c)
-@register_symbolic _and(a, b, c, d)
-@register_symbolic _and(a, b, c, d, e)
-
-# MISO OR gate
-OrTable = OffsetArray([
-                       # 0  1 :U :X :Z :W :L :H :D
-                       0 1 :U :X :X :X 0 1 :X # 0
-                       1 1 1 1 1 1 1 1 1 # 1
-                       :U 1 :U :U :U :U :U 1 :U # :U
-                       :X 1 :U :X :X :X :X 1 :X # :X
-                       :X 1 :U :X :X :X :X 1 :X # :Z
-                       :X 1 :U :X :X :X :X 1 :X # :W
-                       0 1 :U :X :X :X 0 1 :X # :L
-                       1 1 1 1 1 1 1 1 1 # :H
-                       :X 1 :U :X :X :X :X 1 :X], 0:8, 0:8)
-
-function _or2(a, b)
-    i, j = logic(a), logic(b)
-    (typeof(i) != Int || typeof(j) != Int) && return X
-    OrTable[i, j]
-end
-
-function _or(x...)
-    y = [_or2(x[1], x[1])]
-    for i in 2:length(x)
-        push!(y, _or2(x[i], y[i - 1]))
-    end
-    return y[end]
-end
-@register_symbolic _or(x...)
-@register_symbolic _or(a, b)
-@register_symbolic _or(a, b, c)
-@register_symbolic _or(a, b, c, d)
-@register_symbolic _or(a, b, c, d, e)
-@register_symbolic _or(a, b, c, d, e, f, g, h)
-
-# MISO :XOR gate
-
-XorTable = OffsetArray([
-                        #  0  1 :U :X :Z :W :L :H :D
-                        0 1 :U :X :X :X 0 1 :X # 0
-                        1 0 :U :X :X :X 1 0 :X # 1
-                        :U :U :U :U :U :U :U :U :U # :U
-                        :X :X :U :X :X :X :X :X :X # :X
-                        :X :X :U :X :X :X :X :X :X # :Z
-                        :X :X :U :X :X :X :X :X :X # :W
-                        0 1 :U :X :X :X 0 1 :X # :L
-                        1 0 :U :X :X :X 1 0 :X # :H
-                        :X :X :U :X :X :X :X :X :X], 0:8, 0:8)
+# XOR gate
+XorTable = [
+            # U X F0 F1 Z W L H DC
+            U U U U U U U U U     # U
+            U X X X X X X X X     # X
+            U X F0 F1 X X F0 F1 X # F0
+            U X F1 F0 X X F1 F0 X # F1
+            U X X X X X X X X     # Z
+            U X X X X X X X X     # W
+            U X F0 F1 X X F0 F1 X # L
+            U X F1 F0 X X F1 F0 X # H
+            U X X X X X X X X]    # DC
 
 function _xor2(a, b)
-    i, j = logic(a), logic(b)
-    (typeof(i) != Int || typeof(j) != Int) && return X
-    XorTable[i, j]
+    XorTable[logic_level_dict[a], logic_level_dict[b]]
 end
 
 function _xor(x...)
-    y = [_xor2(x[1], 0)]
-    for i in 2:length(x)
+    y = [x[1]]
+    for i in 2:lastindex(x)
         push!(y, _xor2(x[i], y[i - 1]))
     end
     return y[end]
 end
+
 @register_symbolic _xor(x...)
 @register_symbolic _xor(a, b)
 @register_symbolic _xor(a, b, c)
 @register_symbolic _xor(a, b, c, d)
 @register_symbolic _xor(a, b, c, d, e)
-
-# TODO: revisit y[1] for all miso gates for 9-level logic

--- a/src/Electrical/Digital/tables.jl
+++ b/src/Electrical/Digital/tables.jl
@@ -1,18 +1,55 @@
+struct LogicTable{N} <: AbstractArray{Logic, N}
+    logic::Array{Logic, N}
+    function LogicTable(l::Array{Logic})
+        any(i -> i != 9, size(l)) &&
+            throw(ArgumentError("Incorrect number of logic values are passed. A variable of type
+`LogicTable` must have nine entries corresponding to 9 logic levels"))
+        new{ndims(l)}(l)
+    end
+end
+
+Base.size(l::LogicTable) = size(l.logic)
+
+Base.axes(l::LogicTable) = axes(l.logic)
+
+getindex(s::LogicTable, l::Logic) = getindex(s.logic, get_logic_level(l))
+function Base.getindex(s::LogicTable, i1::Logic, i2::Logic)
+    getindex(s.logic, get_logic_level(i1), get_logic_level(i2))
+end
+function Base.getindex(s::LogicTable, i1::Logic, i2::Logic,
+                       I::Logic...)
+    getindex(s.logic, get_logic_level(i1), get_logic_level(i2), get_logic_level(I...)...)
+end
+
+getindex(s::LogicTable, l::Int) = getindex(s.logic, l)
+function getindex(s::LogicTable, i1::Int, i2::Int, I::Int...)
+    getindex(s.logic, i1, i2, I...)
+end
+
+function Base.setindex!(A::LogicTable, x::Logic, i1::Int)
+    setindex!(A.logic, x, i1)
+end
+function Base.setindex!(A::LogicTable, x::Logic, i1::Int, i2::Int, I::Int...)
+    setindex!(A.logic, x, i1, i2, I...)
+end
+
+get_logic_level(l::LogicTable) = Int.(l.logic)
+
 # AND gate
-const AndTable = [
-                  # U X F0 F1 Z W L H DC
-                  U U F0 U U U F0 U U        # U
-                  U X F0 X X X F0 X X        # X
-                  F0 F0 F0 F0 F0 F0 F0 F0 F0 # F0
-                  U X F0 F1 X X F0 F1 X      # F1
-                  U X F0 X X X F0 X X        # Z
-                  U X F0 X X X F0 X X        # W
-                  F0 F0 F0 F0 F0 F0 F0 F0 F0 # L
-                  U X F0 F1 X X F0 F1 X      # H
-                  U X F0 X X X F0 X X]       # DC
+const AndTable = LogicTable([
+                             # U X F0 F1 Z W L H DC
+                             U U F0 U U U F0 U U        # U
+                             U X F0 X X X F0 X X        # X
+                             F0 F0 F0 F0 F0 F0 F0 F0 F0 # F0
+                             U X F0 F1 X X F0 F1 X      # F1
+                             U X F0 X X X F0 X X        # Z
+                             U X F0 X X X F0 X X        # W
+                             F0 F0 F0 F0 F0 F0 F0 F0 F0 # L
+                             U X F0 F1 X X F0 F1 X      # H
+                             U X F0 X X X F0 X X])       # DC
 
 function _and2(a::Logic, b::Logic)
-    AndTable[get_logic_level(a), get_logic_level(b)]
+    AndTable[a, b]
 end
 _and2(a::Number, b::Logic) = _and2(convert(Logic, a), b)
 _and2(a::Logic, b::Number) = _and2(a, convert(Logic, b))
@@ -29,28 +66,28 @@ end
 @register_symbolic _and(a, b)
 
 # NOT gate
-const NotTable = [U, X, F1, F0, X, X, F1, F0, X]
+const NotTable = LogicTable([U, X, F1, F0, X, X, F1, F0, X])
 
-_not(x::Logic) = NotTable[get_logic_level(x)]
+_not(x::Logic) = NotTable[x]
 _not(x::Number) = _not(convert(Logic, x))
 
 @register_symbolic _not(x)
 
 # OR gate
-const OrTable = [
-                 # U X F0 F1 Z W L H DC
-                 U U U F1 U U U F1 U        # U
-                 U X X F1 X X X F1 X        # X
-                 U X F0 F1 X X F0 F1 X      # F0
-                 F1 F1 F1 F1 F1 F1 F1 F1 F1 # F1
-                 U X X F1 X X X F1 X        # Z
-                 U X X F1 X X X F1 X        # W
-                 U X F0 F1 X X F0 F1 X      # L
-                 F1 F1 F1 F1 F1 F1 F1 F1 F1 # H
-                 U X X F1 X X X F1 X]       # DC
+const OrTable = LogicTable([
+                            # U X F0 F1 Z W L H DC
+                            U U U F1 U U U F1 U        # U
+                            U X X F1 X X X F1 X        # X
+                            U X F0 F1 X X F0 F1 X      # F0
+                            F1 F1 F1 F1 F1 F1 F1 F1 F1 # F1
+                            U X X F1 X X X F1 X        # Z
+                            U X X F1 X X X F1 X        # W
+                            U X F0 F1 X X F0 F1 X      # L
+                            F1 F1 F1 F1 F1 F1 F1 F1 F1 # H
+                            U X X F1 X X X F1 X])       # DC
 
 function _or2(a::Logic, b::Logic)
-    OrTable[get_logic_level(a), get_logic_level(b)]
+    OrTable[a, b]
 end
 _or2(a::Number, b::Logic) = _or2(convert(Logic, a), b)
 _or2(a::Logic, b::Number) = _or2(a, convert(Logic, b))
@@ -67,20 +104,20 @@ end
 @register_symbolic _or(a, b)
 
 # XOR gate
-const XorTable = [
-                  # U X F0 F1 Z W L H DC
-                  U U U U U U U U U     # U
-                  U X X X X X X X X     # X
-                  U X F0 F1 X X F0 F1 X # F0
-                  U X F1 F0 X X F1 F0 X # F1
-                  U X X X X X X X X     # Z
-                  U X X X X X X X X     # W
-                  U X F0 F1 X X F0 F1 X # L
-                  U X F1 F0 X X F1 F0 X # H
-                  U X X X X X X X X]    # DC
+const XorTable = LogicTable([
+                             # U X F0 F1 Z W L H DC
+                             U U U U U U U U U     # U
+                             U X X X X X X X X     # X
+                             U X F0 F1 X X F0 F1 X # F0
+                             U X F1 F0 X X F1 F0 X # F1
+                             U X X X X X X X X     # Z
+                             U X X X X X X X X     # W
+                             U X F0 F1 X X F0 F1 X # L
+                             U X F1 F0 X X F1 F0 X # H
+                             U X X X X X X X X])    # DC
 
 function _xor2(a::Logic, b::Logic)
-    XorTable[get_logic_level(a), get_logic_level(b)]
+    XorTable[a, b]
 end
 _xor2(a::Number, b::Logic) = _xor2(convert(Logic, a), b)
 _xor2(a::Logic, b::Number) = _xor2(a, convert(Logic, b))

--- a/src/Electrical/Digital/tables.jl
+++ b/src/Electrical/Digital/tables.jl
@@ -7,7 +7,7 @@ logicmap = Dict(0 => 0,
                 :X => 3, # Unknown
                 :Z => 4, # High Impedence
                 :W => 5, # Weak Unknown
-                :L => 6, # Weak Low                
+                :L => 6, # Weak Low
                 :H => 7, # Weak High
                 :D => 8) # Don't Care; standard representation is `-`
 

--- a/src/Electrical/Digital/tables.jl
+++ b/src/Electrical/Digital/tables.jl
@@ -12,7 +12,7 @@ const AndTable = [
                   U X F0 X X X F0 X X]       # DC
 
 function _and2(a::Logic, b::Logic)
-    AndTable[a.level, b.level]
+    AndTable[get_logic_level(a), get_logic_level(b)]
 end
 _and2(a::Number, b::Logic) = _and2(convert(Logic, a), b)
 _and2(a::Logic, b::Number) = _and2(a, convert(Logic, b))
@@ -50,7 +50,7 @@ const OrTable = [
                  U X X F1 X X X F1 X]       # DC
 
 function _or2(a::Logic, b::Logic)
-    OrTable[a.level, b.level]
+    OrTable[get_logic_level(a), get_logic_level(b)]
 end
 _or2(a::Number, b::Logic) = _or2(convert(Logic, a), b)
 _or2(a::Logic, b::Number) = _or2(a, convert(Logic, b))
@@ -80,7 +80,7 @@ const XorTable = [
                   U X X X X X X X X]    # DC
 
 function _xor2(a::Logic, b::Logic)
-    XorTable[a.level, b.level]
+    XorTable[get_logic_level(a), get_logic_level(b)]
 end
 _xor2(a::Number, b::Logic) = _xor2(convert(Logic, a), b)
 _xor2(a::Logic, b::Number) = _xor2(a, convert(Logic, b))

--- a/src/Electrical/Electrical.jl
+++ b/src/Electrical/Electrical.jl
@@ -41,6 +41,8 @@ export StdLogicVector, StdULogicVector,
        get_logic_level
 include("Digital/logic_vectors.jl")
 
+export LogicTable,
+       AndTable, OrTable, NotTable, XorTable
 include("Digital/tables.jl")
 
 end

--- a/src/Electrical/Electrical.jl
+++ b/src/Electrical/Electrical.jl
@@ -5,7 +5,6 @@ This library contains electrical components to build up analog circuits.
 module Electrical
 
 using ModelingToolkit, Symbolics, IfElse
-using OffsetArrays
 using ..Thermal: HeatPort
 using ..Mechanical.Rotational: Flange, Support
 using ..Blocks: RealInput, RealOutput
@@ -28,7 +27,6 @@ include("Analog/sources.jl")
 
 # include("Digital/components.jl")
 # include("Digital/gates.jl")
-# include("Digital/tables.jl")
 # include("Digital/sources.jl")
 
 # TODO:
@@ -38,5 +36,7 @@ include("Analog/sources.jl")
 
 export Logic
 include("Digital/logic.jl")
+
+include("Digital/tables.jl")
 
 end

--- a/src/Electrical/Electrical.jl
+++ b/src/Electrical/Electrical.jl
@@ -25,7 +25,6 @@ include("Analog/sensors.jl")
 export Voltage, Current
 include("Analog/sources.jl")
 
-# include("Digital/logic_vectors.jl")
 # include("Digital/gates.jl")
 # include("Digital/sources.jl")
 
@@ -38,7 +37,8 @@ export Logic
 include("Digital/logic.jl")
 
 export StdLogicVector, StdULogicVector,
-       std_ulogic, UX01, UX01Z, X01, X01Z
+       std_ulogic, UX01, UX01Z, X01, X01Z,
+       get_logic_level
 include("Digital/logic_vectors.jl")
 
 include("Digital/tables.jl")

--- a/src/Electrical/Electrical.jl
+++ b/src/Electrical/Electrical.jl
@@ -37,7 +37,8 @@ include("Analog/sources.jl")
 export Logic
 include("Digital/logic.jl")
 
-export StdLogicVector, StdULogicVector
+export StdLogicVector, StdULogicVector,
+       std_ulogic, UX01, UX01Z, X01, X01Z
 include("Digital/logic_vectors.jl")
 
 include("Digital/tables.jl")

--- a/src/Electrical/Electrical.jl
+++ b/src/Electrical/Electrical.jl
@@ -25,7 +25,7 @@ include("Analog/sensors.jl")
 export Voltage, Current
 include("Analog/sources.jl")
 
-# include("Digital/components.jl")
+# include("Digital/logic_vectors.jl")
 # include("Digital/gates.jl")
 # include("Digital/sources.jl")
 
@@ -36,6 +36,9 @@ include("Analog/sources.jl")
 
 export Logic
 include("Digital/logic.jl")
+
+export StdLogicVector, StdULogicVector
+include("Digital/logic_vectors.jl")
 
 include("Digital/tables.jl")
 

--- a/src/Electrical/Electrical.jl
+++ b/src/Electrical/Electrical.jl
@@ -36,4 +36,7 @@ include("Analog/sources.jl")
 # - machines
 # - multi-phase
 
+export Logic
+include("Digital/logic.jl")
+
 end

--- a/test/Electrical/digital.jl
+++ b/test/Electrical/digital.jl
@@ -1,5 +1,58 @@
 using ModelingToolkitStandardLibrary.Electrical, ModelingToolkit, OrdinaryDiffEq, Test
-using ModelingToolkitStandardLibrary.Electrical: Set, Reset, _and, _or, _not
+using ModelingToolkitStandardLibrary.Electrical: _and, _or, _not, _xor
+using ModelingToolkitStandardLibrary.Electrical: U, X, F0, F1, Z, W, L, H, DC
+using ModelingToolkitStandardLibrary.Electrical: AndTable, OrTable, NotTable, XorTable
+using ModelingToolkitStandardLibrary.Electrical: convert_to_logic, get_logic_level
+# using ModelingToolkitStandardLibrary.Electrical: Set, Reset
+
+@testset "Logic, logic-vectors and helpers" begin
+    # Logic and helper functions
+    @test length(instances(Logic)) == 9
+    @test convert_to_logic.([1, 0]) |> typeof == Vector{Logic}
+    @test get_logic_level(Z) == 5
+
+    # Logic zeros and ones
+    @test zero(Logic) == zero(U) == F0
+    @test one(Logic) == one(U) == F1
+    @test ones(Logic, 2, 2) == [F1 F1
+                                F1 F1]
+
+    # Logic vectors
+    u_logic = StdULogicVector([U, W, X, 1])
+    @test typeof(u_logic.logic) == Vector{Logic}
+    @test get_logic_level(u_logic) == [1, 6, 2, 4]
+
+    logic = StdLogicVector([U, W, X, 1])
+    @test typeof(logic.logic) == Vector{Logic}
+    @test get_logic_level(logic) == [1, 6, 2, 4]
+
+    # Predefiend logic vectors
+    @test std_ulogic.logic == [U, X, F0, F1, Z, W, L, H, DC]
+    @test UX01.logic == [U, X, F0, F1]
+    @test UX01Z.logic == [U, X, F0, F1, Z]
+    @test X01.logic == [X, F0, F1]
+    @test X01Z.logic == [X, F0, F1, Z]
+
+    # Logic helper functions
+    @test get_logic_level.([U, X, F0, F1, Z, W, L, H, DC]) == 1:9
+    @test convert_to_logic.([1, 0, U]) == [F1, F0, U]
+end
+@testset "Logic tables and logic gate helpers" begin
+    # logic tables and logic gate helpers
+    @test size(AndTable) == size(OrTable) == size(XorTable) == (9, 9)
+    @test size(NotTable) == (9,)
+
+    @test _and(1, 1, 1, 1, 1, 0) == F0
+    @test _or(0, 1, 1, 1) == F1
+    @test _xor(0, 1, 1, 1, 1, 1) == F1
+    @test _not(1) == F0
+
+    A = [U, W, Z, F1, F0]
+    B = [U, W, X, F0, DC]
+    _xor.(A, B) == _and.(_or.(A, _not.(B)), _or.(_not.(A), B))
+end
+
+#=
 
 @parameters t
 
@@ -374,5 +427,7 @@ end
 
     u0 = []
     prob = ODEProblem(sys, u0, (0, 1.5))
-    # sol = solve(prob, Rosenbrock23())        
+    # sol = solve(prob, Rosenbrock23())
 end
+
+=#

--- a/test/Electrical/digital.jl
+++ b/test/Electrical/digital.jl
@@ -59,7 +59,19 @@ using ModelingToolkitStandardLibrary.Electrical: get_logic_level
     @test_throws "3 isn't a valid `Logic` value" convert(Logic, 3)
 end
 
-@testset "Logic tables and logic gate helpers" begin
+@testset "Logic Tables" begin
+    # LogicTable vec-or-mat and helpers
+    test_not_logic_table = LogicTable([U, X, F1, F0, X, X, F1, F0, X])
+    @test test_not_logic_table[1] == U
+    @test test_not_logic_table[F1] == F0
+
+    test_not_logic_table[1] = X
+    @test test_not_logic_table[1] == X
+
+    @test_throws ArgumentError LogicTable([U; U])
+end
+
+@testset "Gate tables and logic gate helpers" begin
     # logic tables and logic gate helpers
     @test size(AndTable) == size(OrTable) == size(XorTable) == (9, 9)
     @test size(NotTable) == (9,)

--- a/test/Electrical/digital.jl
+++ b/test/Electrical/digital.jl
@@ -38,13 +38,20 @@ using ModelingToolkitStandardLibrary.Electrical: get_logic_level
     @test X01Z.logic == [X, F0, F1, Z]
 
     # Logic vector helpers
-    logic_vector = StdULogicVector([U F0
-                                    F1 X])
-    size(logic_vector) == (2, 2)
-    axes(logic_vector) == (Base.OneTo(2), Base.OneTo(2))
-    getindex(logic_vector, 1, 1) == U
+    test_logic_matrix = StdULogicVector([U F0
+                                         F1 X])
+    test_logic_vector = StdLogicVector([U, F0, F1, X])
 
-    getindex(StdLogicVector([U, F0, F1, X]), 1) == U
+    size(test_logic_matrix) == (2, 2)
+    axes(test_logic_matrix) == (Base.OneTo(2), Base.OneTo(2))
+
+    getindex(test_logic_matrix, 1, 1) == U
+    getindex(test_logic_vector, 1) == U
+
+    setindex!(test_logic_matrix, Z, 1, 1)
+    @test test_logic_matrix[1, 1] == Z
+    setindex!(test_logic_vector, Z, 1)
+    @test test_logic_vector[1] == Z
 
     # Logic helper functions
     @test get_logic_level.([U, X, F0, F1, Z, W, L, H, DC]) == 1:9
@@ -62,8 +69,8 @@ end
     @test _or(0, 1, U, 1) == F1
     @test _xor(0, 1, U, U, 1, 1) == U
     # tests (Number, Logic) input
-    @info _and(1, F1) == F1
-    @info _or(0, F0) == F0
+    @test _and(1, F1) == F1
+    @test _or(0, F0) == F0
     @test _xor(1, F0) == F1
     # tests Number and Logic (via internal convert)
     @test _not(1) == F0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using SafeTestsets
 
 # Electrical
 @safetestset "Analog Circuits" begin include("Electrical/analog.jl") end
-#@safetestset "Digital Circuits" begin include("Electrical/digital.jl") end
+@safetestset "Digital Circuits" begin include("Electrical/digital.jl") end
 @safetestset "RC Circuit Demo" begin include("demo.jl") end
 @safetestset "Chua Circuit Demo" begin include("chua_circuit.jl") end
 


### PR DESCRIPTION
First in series of PRs to implement the entire IEEE.Std_logic_1164 in Julia

- [x] Adds Logic and its 9 levels
- [x] Accordingly refactors AndTable, OrTable, NotTable, XorTable
- [x] Accordingly refactors _and, _or, _not, _xor
- [x] Adds StdULogicVector and few predefined vectors and StdLogicVector
- [x] Adds relevant tests


----- 
This PR will be followed up to add things like:
- Resolution table
- Inter-conversions from one range of logic-levels to other range
- Digital sources, clocks
- High level DiscreteSystems of gates
- And then revival of Adders, En(/De)coders, (De)Muxes