### PR TITLE
refactor: `:Success` -> `ReturnCode.Success`

### DIFF
--- a/test/Blocks/continuous.jl
+++ b/test/Blocks/continuous.jl
@@ -1,5 +1,6 @@
 using ModelingToolkit, ModelingToolkitStandardLibrary, OrdinaryDiffEq
 using ModelingToolkitStandardLibrary.Blocks
+using OrdinaryDiffEq: ReturnCode.Success
 
 @parameters t
 
@@ -7,7 +8,7 @@ using ModelingToolkitStandardLibrary.Blocks
 Testing strategy:
 The general strategy is to test systems using simple intputs where the solution
 is known on closed form. For algebraic systems (without differential variables),
-an integrator with a constant input is often used together with the system under test. 
+an integrator with a constant input is often used together with the system under test.
 =#
 
 @testset "Constant" begin
@@ -17,9 +18,9 @@ an integrator with a constant input is often used together with the system under
     sys = structural_simplify(iosys)
     prob = ODEProblem(sys, Pair[int.x => 1.0], (0.0, 1.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test all(sol[c.output.u] .≈ 1)
-    @test sol[int.output.u][end] .≈ 2 # expected solution 
+    @test sol[int.output.u][end] .≈ 2 # expected solution
 end
 
 @testset "Derivative" begin
@@ -35,7 +36,7 @@ end
     sys = structural_simplify(iosys)
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 10.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test all(isapprox.(sol[source.output.u], sol[int.output.u], atol = 1e-1))
 end
 
@@ -49,7 +50,7 @@ end
     sys = structural_simplify(iosys)
     prob = ODEProblem(sys, Pair[], (0.0, 100.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[pt1.output.u]≈pt1_func.(sol.t, k, T) atol=1e-3
 
     # Test highpass feature
@@ -58,7 +59,7 @@ end
     sys = structural_simplify(iosys)
     prob = ODEProblem(sys, Pair[], (0.0, 100.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[pt1.output.u]≈k .- pt1_func.(sol.t, k, T) atol=1e-3
 end
 
@@ -82,7 +83,7 @@ end
     sys = structural_simplify(iosys)
     prob = ODEProblem(sys, Pair[], (0.0, 100.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[pt2.output.u]≈pt2_func.(sol.t, k, w, d) atol=1e-3
 end
 
@@ -101,7 +102,7 @@ end
     sys = structural_simplify(model)
     prob = ODEProblem(sys, Pair[], (0.0, 100.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     # initial condition
     @test sol[ss.x[1]][1]≈0 atol=1e-3
     @test sol[ss.x[2]][1]≈0 atol=1e-3
@@ -121,7 +122,7 @@ end
     sys = structural_simplify(model)
     prob = ODEProblem(sys, Pair[], (0.0, 100.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
 
     @test sol[ss.x[1]][end ÷ 2]≈0 atol=1e-3 # Test that x did not move
     @test sol[ss.x[1]][end]≈0 atol=1e-3 # Test that x did not move
@@ -158,7 +159,7 @@ end
     sys = structural_simplify(model)
     prob = ODEProblem(sys, Pair[], (0.0, 100.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test all(isapprox.(sol[ref.output.u], re_val, atol = 1e-3))  # check reference
     @test sol[plant.output.u][end]≈re_val atol=1e-3 # zero control error after 100s
 end
@@ -180,7 +181,7 @@ end
     sys = structural_simplify(model)
     prob = ODEProblem(sys, Pair[], (0.0, 100.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test all(isapprox.(sol[ref.output.u], re_val, atol = 1e-3))  # check reference
     @test sol[plant.output.u][end]≈re_val atol=1e-3 # zero control error after 100s
 
@@ -197,7 +198,7 @@ end
         sys = structural_simplify(model)
         prob = ODEProblem(sys, Pair[], (0.0, 100.0))
         sol = solve(prob, Rodas4())
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test all(isapprox.(sol[ref.output.u], re_val, atol = 1e-3))  # check reference
         @test sol[plant.output.u][end]≈re_val atol=1e-3 # zero control error after 100s
     end
@@ -215,7 +216,7 @@ end
         sys = structural_simplify(model)
         prob = ODEProblem(sys, Pair[], (0.0, 100.0))
         sol = solve(prob, Rodas4())
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test all(isapprox.(sol[ref.output.u], re_val, atol = 1e-3))  # check reference
         @test sol[plant.output.u][end] > 1 # without I there will be a steady-state error
     end
@@ -262,8 +263,8 @@ end
         sol = solve(prob, Rodas4())
     end
 
-    @test sol.retcode == :Success
-    @test sol_lim.retcode == :Success
+    @test sol.retcode == Success
+    @test sol_lim.retcode == ReturnCode.Success
     @test all(isapprox.(sol[ref.output.u], re_val, atol = 1e-3))  # check reference
     @test all(isapprox.(sol_lim[ref.output.u], re_val, atol = 1e-3))  # check reference
     @test sol[plant.output.u][end]≈re_val atol=1e-3 # zero control error after 100s
@@ -292,7 +293,7 @@ end
     sol = solve(prob, Rodas4())
 
     # Plots.plot(sol, vars=[plant.output.u, plant.input.u])
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test all(isapprox.(sol[ref.output.u], re_val, atol = 1e-3))  # check reference
     @test sol[plant.output.u][end]≈re_val atol=1e-3 # zero control error after 100s
     @test all(-1.5 .<= sol[pid_controller.ctr_output.u] .<= 1.5) # test limit
@@ -312,7 +313,7 @@ end
         sol = solve(prob, Rodas4())
 
         # Plots.plot(sol, vars=[plant.output.u, plant.input.u])
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test all(isapprox.(sol[ref.output.u], re_val, atol = 1e-3))  # check reference
         @test sol[plant.output.u][end]≈re_val atol=1e-3 # zero control error after 100s
         @test all(-1.5 .<= sol[pid_controller.ctr_output.u] .<= 1.5) # test limit
@@ -332,7 +333,7 @@ end
         sol = solve(prob, Rodas4())
 
         # Plots.plot(sol, vars=[plant.output.u, plant.input.u])
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test all(isapprox.(sol[ref.output.u], re_val, atol = 1e-3))  # check reference
         @test sol[plant.output.u][end] > 0.5 # without I there will be a steady-state error
         @test all(-1.5 .<= sol[pid_controller.ctr_output.u] .<= 1.5) # test limit
@@ -353,7 +354,7 @@ end
             sol = solve(prob, Rodas4())
 
             # Plots.plot(sol, vars=[plant.output.u, plant.input.u])
-            @test sol.retcode == :Success
+            @test sol.retcode == Success
             @test all(isapprox.(sol[ref.output.u], re_val, atol = 1e-3))  # check reference
             sol[pid_controller.addP.output.u] == -sol[pid_controller.measurement.u]
             @test sol[plant.output.u][end]≈re_val atol=1e-3 # zero control error after 100s
@@ -374,7 +375,7 @@ end
             sol = solve(prob, Rodas4())
 
             # Plots.plot(sol, vars=[plant.output.u, plant.input.u])
-            @test sol.retcode == :Success
+            @test sol.retcode == Success
             @test all(isapprox.(sol[ref.output.u], re_val, atol = 1e-3))  # check reference
             @test sol[plant.output.u][end]≈re_val atol=1e-3 # zero control error after 100s
             sol[pid_controller.addD.output.u] == -sol[pid_controller.measurement.u]
@@ -396,7 +397,7 @@ end
         sol = solve(prob, Rodas4())
 
         # Plots.plot(sol, vars=[plant.output.u, plant.input.u])
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test all(isapprox.(sol[ref.output.u], re_val, atol = 1e-3))  # check reference
         @test sol[plant.output.u][end]≈re_val atol=1e-3 # zero control error after 100s
         @test all(-1.5 .<= sol[pid_controller.ctr_output.u] .<= 1.5) # test limit

--- a/test/Blocks/math.jl
+++ b/test/Blocks/math.jl
@@ -2,6 +2,7 @@ using ModelingToolkitStandardLibrary.Blocks
 using ModelingToolkit, OrdinaryDiffEq, Test
 using ModelingToolkitStandardLibrary.Blocks: _clamp, _dead_zone
 using ModelingToolkit: inputs, unbound_inputs, bound_inputs
+using OrdinaryDiffEq: ReturnCode.Success
 
 @parameters t
 
@@ -19,7 +20,7 @@ using ModelingToolkit: inputs, unbound_inputs, bound_inputs
     sol = solve(prob, Rodas4())
 
     @test isequal(unbound_inputs(sys), [])
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test all(sol[c.output.u] .≈ 1)
     @test sol[int.output.u][end] ≈ 2 # expected solution after 1s
 end
@@ -43,7 +44,7 @@ end
 
     sol = solve(prob, Rodas4())
     @test isequal(unbound_inputs(sys), [])
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[int.output.u][end] ≈ 2 # expected solution after 1s
 end
 
@@ -63,7 +64,7 @@ end
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 1.0))
     sol = solve(prob, Rodas4())
     @test isequal(unbound_inputs(sys), [])
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[add.output.u] ≈ 1 .+ sin.(2 * pi * sol.t)
 
     @testset "weights" begin
@@ -81,7 +82,7 @@ end
         prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 1.0))
         sol = solve(prob, Rodas4())
         @test isequal(unbound_inputs(sys), [])
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test sol[add.output.u] ≈ k1 .* 1 .+ k2 .* sin.(2 * pi * sol.t)
     end
 end
@@ -104,7 +105,7 @@ end
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 1.0))
     sol = solve(prob, Rodas4())
     @test isequal(unbound_inputs(sys), [])
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[add.output.u] ≈ 1 .+ sin.(2 * pi * sol.t) .+ sin.(2 * pi * 2 * sol.t)
 
     @testset "weights" begin
@@ -124,7 +125,7 @@ end
         prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 1.0))
         sol = solve(prob, Rodas4())
         @test isequal(unbound_inputs(sys), [])
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test sol[add.output.u] ≈
               k1 .* 1 .+ k2 .* sin.(2 * pi * sol.t) .+ k3 .* sin.(2 * pi * 2 * sol.t)
     end
@@ -146,7 +147,7 @@ end
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 1.0))
     sol = solve(prob, Rodas4())
     @test isequal(unbound_inputs(sys), [])
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[prod.output.u] ≈ 2 * sin.(2 * pi * sol.t)
 end
 
@@ -166,7 +167,7 @@ end
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 1.0))
     sol = solve(prob, Rodas4())
     @test isequal(unbound_inputs(sys), [])
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[div.output.u] ≈ sin.(2 * pi * sol.t) ./ 2
 end
 
@@ -184,7 +185,7 @@ end
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 1.0))
     sol = solve(prob, Rodas4())
     @test isequal(unbound_inputs(sys), [])
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[absb.output.u] ≈ abs.(sin.(2 * pi * sol.t))
 end
 
@@ -228,7 +229,7 @@ end
         prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 1.0))
         sol = solve(prob, Rodas4())
         @test isequal(unbound_inputs(sys), [])
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test sol[b.output.u] ≈ func.(sol[source.output.u])
     end
 
@@ -246,7 +247,7 @@ end
         prob = ODEProblem(sys, Pair[int.x => 0.0, b.input.u => 2.0], (0.0, 1.0))
         sol = solve(prob, Rodas4())
         @test isequal(unbound_inputs(sys), [])
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test sol[b.output.u] ≈ func.(sol[source.output.u])
     end
 end
@@ -271,6 +272,6 @@ end
     @test isequal(unbound_inputs(sys), [])
     @test all(map(u -> u in Set([b.input1.u, b.input2.u, int.input.u]), bound_inputs(sys)))
     @test all(map(u -> u in Set([b.input1.u, b.input2.u, int.input.u]), inputs(sys)))
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[int.input.u] ≈ atan.(sol[c1.output.u], sol[c2.output.u])
 end

--- a/test/Blocks/nonlinear.jl
+++ b/test/Blocks/nonlinear.jl
@@ -1,6 +1,7 @@
 using ModelingToolkit, OrdinaryDiffEq
 using ModelingToolkitStandardLibrary.Blocks
 using ModelingToolkitStandardLibrary.Blocks: _clamp, _dead_zone
+using OrdinaryDiffEq: ReturnCode.Success
 
 @parameters t
 
@@ -19,7 +20,7 @@ using ModelingToolkitStandardLibrary.Blocks: _clamp, _dead_zone
         prob = ODEProblem(sys, [int.x => 1.0], (0.0, 1.0))
 
         sol = solve(prob, Rodas4())
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test sol[int.output.u][end] ≈ 2
         @test sol[sat.output.u][end] ≈ 0.8
     end
@@ -40,7 +41,7 @@ using ModelingToolkitStandardLibrary.Blocks: _clamp, _dead_zone
         prob = ODEProblem(sys, Pair[], (0.0, 10.0))
 
         sol = solve(prob, Rodas4())
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test all(abs.(sol[lim.output.u]) .<= 0.5)
         @test all(isapprox.(sol[lim.output.u], _clamp.(sol[source.output.u], y_min, y_max),
                             atol = 1e-2))
@@ -66,7 +67,7 @@ end
         prob = ODEProblem(sys, [int.x => 1.0], (0.0, 1.0))
         sol = solve(prob, Rodas4())
 
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test all(sol[int.output.u][end] .≈ 2)
     end
 
@@ -85,7 +86,7 @@ end
         prob = ODEProblem(sys, [int.x => 1.0], (0.0, 10.0))
         sol = solve(prob, Rodas4())
 
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test all(sol[dz.output.u] .<= 2)
         @test all(sol[dz.output.u] .>= -1)
         @test all(isapprox.(sol[dz.output.u],
@@ -111,7 +112,7 @@ end
 
     tS = 0.01
     sol = solve(prob, Rodas4(), saveat = tS, abstol = 1e-10, reltol = 1e-10)
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test all(abs.(sol[rl.output.u]) .<= 0.51)
     @test all(-1 - 1e-5 .<= diff(sol[rl.output.u]) ./ tS .<= 1 + 1e-5) # just an approximation
 end

--- a/test/Blocks/sources.jl
+++ b/test/Blocks/sources.jl
@@ -3,6 +3,7 @@ using ModelingToolkitStandardLibrary.Blocks
 using ModelingToolkitStandardLibrary.Blocks: smooth_sin, smooth_cos, smooth_damped_sin,
                                              smooth_square, smooth_step, smooth_ramp,
                                              smooth_triangular, triangular, square
+using OrdinaryDiffEq: ReturnCode.Success
 
 @parameters t
 
@@ -19,7 +20,7 @@ using ModelingToolkitStandardLibrary.Blocks: smooth_sin, smooth_cos, smooth_damp
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 10.0))
 
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[src.output.u][end]≈2 atol=1e-3
 end
 
@@ -49,7 +50,7 @@ end
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 10.0))
 
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[src.output.u]≈sine.(sol.t, frequency, amplitude, phase, offset, start_time) atol=1e-3
 
     @named smooth_src = Sine(frequency = frequency,
@@ -68,7 +69,7 @@ end
     smooth_prob = ODEProblem(smooth_sys, Pair[int.x => 0.0], (0.0, 10.0))
     smooth_sol = solve(smooth_prob, Rodas4())
 
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test smooth_sol[smooth_src.output.u]≈smooth_sin.(smooth_sol.t, δ, frequency, amplitude,
                                                       phase, offset, start_time) atol=1e-3
 end
@@ -102,7 +103,7 @@ end
     sys = structural_simplify(iosys)
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 10.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[src.output.u]≈cosine.(sol.t, frequency, amplitude, phase, offset, start_time) atol=1e-3
 
     @named smooth_src = Cosine(frequency = frequency,
@@ -121,7 +122,7 @@ end
     smooth_prob = ODEProblem(smooth_sys, Pair[int.x => 0.0], (0.0, 10.0))
     smooth_sol = solve(smooth_prob, Rodas4())
 
-    @test smooth_sol.retcode == :Success
+    @test smooth_sol.retcode == Success
     @test smooth_sol[smooth_src.output.u]≈smooth_cos.(smooth_sol.t, δ, frequency, amplitude,
                                                       phase, offset, start_time) atol=1e-3
 end
@@ -143,7 +144,7 @@ end
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 10.0))
 
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[src.output.u]≈cont_clock.(sol.t, offset, start_time) atol=1e-3
 end
 
@@ -168,7 +169,7 @@ end
     sys = structural_simplify(iosys)
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 10.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[src.output.u]≈ramp.(sol.t, offset, height, duration, start_time) atol=1e-3
 
     start_time = 2
@@ -184,7 +185,7 @@ end
     smooth_prob = ODEProblem(smooth_sys, Pair[int.x => 0.0], (0.0, 10.0))
     smooth_sol = solve(smooth_prob, Rodas4())
 
-    @test smooth_sol.retcode == :Success
+    @test smooth_sol.retcode == Success
     @test smooth_sol[smooth_src.output.u]≈smooth_ramp.(smooth_sol.t, δ, height, duration,
                                                        offset, start_time) atol=1e-3
 end
@@ -207,7 +208,7 @@ end
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 10.0))
     sol = solve(prob, Rodas4())
 
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[src.output.u]≈step.(sol.t, offset, height, start_time) atol=1e-2
 
     # test with duration
@@ -224,7 +225,7 @@ end
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 10.0))
     sol = solve(prob, Rodas4(), dtmax = 0.1) # set dtmax to prevent the solver from overstepping the entire step disturbance
 
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[src.output.u]≈step.(sol.t, offset, height, start_time) -
                             step.(sol.t, 0, height, start_time + duration) atol=1e-2
 
@@ -240,7 +241,7 @@ end
     smooth_prob = ODEProblem(smooth_sys, Pair[int.x => 0.0], (0.0, 10.0))
     smooth_sol = solve(smooth_prob, Rodas4(), dtmax = 0.1) # set dtmax to prevent the solver from overstepping the entire step disturbance)
 
-    @test smooth_sol.retcode == :Success
+    @test smooth_sol.retcode == Success
     @test smooth_sol[smooth_src.output.u] ≈
           smooth_step.(smooth_sol.t, δ, height, offset, start_time)
 
@@ -257,7 +258,7 @@ end
     smooth_prob = ODEProblem(smooth_sys, Pair[int.x => 0.0], (0.0, 10.0))
     smooth_sol = solve(smooth_prob, Rodas4())
 
-    @test smooth_sol.retcode == :Success
+    @test smooth_sol.retcode == Success
     @test smooth_sol[smooth_src.output.u] ≈
           smooth_step.(smooth_sol.t, δ, height, offset, start_time) -
           smooth_step.(smooth_sol.t, δ, height, 0, start_time + duration)
@@ -283,7 +284,7 @@ end
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 10.0))
     sol = solve(prob, Rodas4())
 
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[src.output.u]≈square.(sol.t, frequency, amplitude, offset, start_time) atol=1e-3
 
     @named smooth_src = Square(frequency = frequency, amplitude = amplitude,
@@ -298,7 +299,7 @@ end
     smooth_prob = ODEProblem(smooth_sys, Pair[int.x => 0.0], (0.0, 10.0))
     smooth_sol = solve(smooth_prob, Rodas4())
 
-    @test smooth_sol.retcode == :Success
+    @test smooth_sol.retcode == Success
     @test smooth_sol[smooth_src.output.u]≈smooth_square.(smooth_sol.t, δ, frequency,
                                                          amplitude, offset, start_time) atol=1e-3
 end
@@ -323,7 +324,7 @@ end
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 4.0))
     sol = solve(prob, Rodas4(), saveat = 0.01)
 
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[src.output.u]≈triangular.(sol.t, frequency, amplitude, offset, start_time) atol=1e-3
 
     @named smooth_src = Triangular(frequency = frequency, amplitude = amplitude,
@@ -338,7 +339,7 @@ end
     smooth_prob = ODEProblem(smooth_sys, Pair[int.x => 0.0], (0.0, 4.0))
     smooth_sol = solve(smooth_prob, Rodas4(), saveat = 0.01)
 
-    @test smooth_sol.retcode == :Success
+    @test smooth_sol.retcode == Success
     @test smooth_sol[smooth_src.output.u]≈smooth_triangular.(smooth_sol.t, δ, frequency,
                                                              amplitude, offset, start_time) atol=1e-3
 end
@@ -363,7 +364,7 @@ end
     sys = structural_simplify(iosys)
     prob = ODEProblem(sys, Pair[int.x => 0.0], (0.0, 10.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[src.output.u]≈exp_sine.(sol.t, amplitude, frequency, damping, phase,
                                       start_time) atol=1e-3
 
@@ -380,7 +381,7 @@ end
     smooth_prob = ODEProblem(smooth_sys, Pair[int.x => 0.0], (0.0, 10.0))
     smooth_sol = solve(smooth_prob, Rodas4())
 
-    @test smooth_sol.retcode == :Success
+    @test smooth_sol.retcode == Success
     @test smooth_sol[smooth_src.output.u]≈smooth_damped_sin.(smooth_sol.t, δ, frequency,
                                                              amplitude, damping, phase,
                                                              offset, start_time) atol=1e-3

--- a/test/Electrical/analog.jl
+++ b/test/Electrical/analog.jl
@@ -2,6 +2,8 @@ using ModelingToolkitStandardLibrary.Electrical, ModelingToolkit, OrdinaryDiffEq
 using ModelingToolkitStandardLibrary.Blocks: Step, Constant, Sine, Cosine, ExpSine, Ramp,
                                              Square, Triangular
 using ModelingToolkitStandardLibrary.Blocks: square, triangular
+using OrdinaryDiffEq: ReturnCode.Success
+
 # using Plots
 
 @parameters t
@@ -46,7 +48,7 @@ using ModelingToolkitStandardLibrary.Blocks: square, triangular
     # Plots.plot(sol; vars=[capacitor.v, voltage_sensor.v])
     # Plots.plot(sol; vars=[power_sensor.power, capacitor.i * capacitor.v])
     # Plots.plot(sol; vars=[resistor.i, current_sensor.i])
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[capacitor.v]≈sol[voltage_sensor.v] atol=1e-3
     @test sol[power_sensor.power]≈sol[capacitor.i * capacitor.v] atol=1e-3
     @test sol[resistor.i]≈sol[current_sensor.i] atol=1e-3
@@ -73,7 +75,7 @@ end
     sys = structural_simplify(model)
     prob = ODEProblem(sys, Pair[], (0, 2.0))
     sol = solve(prob, Rodas4()) # has no state; does not work with Tsit5
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[short.v] == sol[R0.v] == zeros(length(sol.t))
     @test sol[R0.i] == zeros(length(sol.t))
     @test sol[R1.p.v][end]≈10 atol=1e-3
@@ -101,7 +103,7 @@ end
     sol = solve(prob, Tsit5())
 
     # Plots.plot(sol; vars=[source.v, capacitor.v])
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[capacitor.v][end]≈10 atol=1e-3
 end
 
@@ -125,7 +127,7 @@ end
     sol = solve(prob, Tsit5())
 
     # Plots.plot(sol; vars=[inductor.i, inductor.i])
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[inductor.i][end]≈10 atol=1e-3
 end
 
@@ -158,9 +160,9 @@ end
         sys = structural_simplify(model)
         prob = ODAEProblem(sys, [capacitor.v => 10.0], (0.0, 10.0))
         sol = solve(prob, Tsit5())
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         sol = solve(prob, Rodas4())
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
 
         # Plots.plot(sol; vars=[voltage.v, capacitor.v])
     end
@@ -186,7 +188,7 @@ end
     prob = ODAEProblem(sys, [capacitor.v => 0.0], (0.0, 10.0))
     sol = solve(prob, Tsit5())
     y(x, st) = (x .> st) .* abs.(collect(x) .- st)
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sum(reduce(vcat, sol.u) .- y(sol.t, start_time))≈0 atol=1e-2
 end
 
@@ -217,7 +219,7 @@ end
           R1.v => 0.0]
     prob = ODEProblem(sys, u0, (0, 100.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[opamp.v2] == sol[C1.v] # Not a great one however. Rely on the plot
     @test sol[opamp.p2.v] == sol[sensor.v]
 
@@ -285,7 +287,7 @@ _damped_sine_wave(x, f, A, st, ϕ, d) = exp((st - x) * d) * A * sin(2 * π * f *
         prob = ODAEProblem(vsys, u0, (0, 10.0))
         sol = solve(prob, dt = 0.1, Tsit5())
 
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test sol[voltage.V.u]≈waveforms(i, sol.t) atol=1e-1
         @test sol[voltage.p.v] ≈ sol[voltage.V.u]
         # For visual inspection
@@ -349,7 +351,7 @@ end
         prob = ODAEProblem(isys, u0, (0, 10.0))
         sol = solve(prob, dt = 0.1, Tsit5())
 
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test sol[current.I.u]≈waveforms(i, sol.t) atol=1e-1
         @test sol[current.I.u]≈sol[current.p.i] atol=1e-1
         # For visual inspection

--- a/test/Electrical/digital.jl
+++ b/test/Electrical/digital.jl
@@ -3,6 +3,8 @@ using ModelingToolkitStandardLibrary.Electrical: _and, _or, _not, _xor
 using ModelingToolkitStandardLibrary.Electrical: U, X, F0, F1, Z, W, L, H, DC, Uninitialized
 using ModelingToolkitStandardLibrary.Electrical: AndTable, OrTable, NotTable, XorTable
 using ModelingToolkitStandardLibrary.Electrical: get_logic_level
+using OrdinaryDiffEq: ReturnCode.Success
+
 # using ModelingToolkitStandardLibrary.Electrical: Set, Reset
 
 @testset "Logic, logic-vectors and helpers" begin
@@ -135,7 +137,7 @@ end
         u0 = []
         prob = ODEProblem(sys, u0, (0, 1.5))
         sol = solve(prob, Rosenbrock23())
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test sol[and.y.val] == _and.(sol[one.d.val], sol[two.d.val])
 
         nand_eqs = [connect(one.d, nand.x1)
@@ -147,7 +149,7 @@ end
         u0 = []
         prob = ODEProblem(sys, u0, (0, 1.5))
         nsol = solve(prob, Rosenbrock23())
-        @test nsol.retcode == :Success
+        @test nsol.retcode == Success
         @test nsol[nand.y.val] == _not.(sol[and.y.val])
     end
 end
@@ -165,7 +167,7 @@ end
         u0 = []
         prob = ODEProblem(sys, u0, (0, 1.5))
         sol = solve(prob, Rosenbrock23())
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test sol[or.y.val] == _or.(sol[one.d.val], sol[two.d.val])
 
         nor_eqs = [connect(one.d, nor.x1)
@@ -177,7 +179,7 @@ end
         u0 = []
         prob = ODEProblem(sys, u0, (0, 1.5))
         nsol = solve(prob, Rosenbrock23())
-        @test nsol.retcode == :Success
+        @test nsol.retcode == Success
         @test nsol[nor.y.val] == _not.(sol[or.y.val])
     end
 end
@@ -195,7 +197,7 @@ end
         u0 = []
         prob = ODEProblem(sys, u0, (0, 1.5))
         sol = solve(prob, Rosenbrock23())
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test sol[xor.y.val] ==
               _or.(_and.(sol[one.d.val], _not.(sol[two.d.val])),
                    _and.(sol[two.d.val], _not.(sol[one.d.val])))
@@ -209,7 +211,7 @@ end
         u0 = []
         prob = ODEProblem(sys, u0, (0, 1.5))
         nsol = solve(prob, Rosenbrock23())
-        @test nsol.retcode == :Success
+        @test nsol.retcode == Success
         @test nsol[xnor.y.val] == _not.(sol[xor.y.val])
     end
 end
@@ -231,7 +233,7 @@ end
         prob = ODEProblem(sys, u0, (0, 1.5))
         sol = solve(prob, Rosenbrock23())
 
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test sol[ha.y0.val] == sol[ha.sum] == _xor.(sol[one.d.val], sol[two.d.val])
     end
 end
@@ -257,7 +259,7 @@ end
         prob = ODEProblem(sys, u0, (0, 1.5))
         sol = solve(prob, Rosenbrock23())
 
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test sol[fa.y0.val] == sol[fa.sum] ==
               _xor(sol[one.d.val], sol[two.d.val], sol[three.d.val])
     end
@@ -294,7 +296,7 @@ end
     prob = ODEProblem(sys, u0, (0, 1.5))
     sol = solve(prob, Rosenbrock23())
 
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[mux2x1.y.val] == sol[mux2x1.d1.val]
     @test sol[mux2x1.y.val] == sol[demux1x2.y0.val]
 
@@ -322,7 +324,7 @@ end
         prob = ODEProblem(sys, u0, (0, 1.5))
         sol = solve(prob, Rosenbrock23())
 
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         (idx1 == 1 && idx0 == 1) && @test sol[mux4x1.y.val] == sol[mux4x1.d0.val]
         (idx1 == 1 && idx0 == 2) && @test sol[mux4x1.y.val] == sol[mux4x1.d1.val]
         (idx1 == 2 && idx0 == 1) && @test sol[mux4x1.y.val] == sol[mux4x1.d2.val]
@@ -363,7 +365,7 @@ end
         prob = ODEProblem(sys, u0, (0, 1.5))
         sol = solve(prob, Rosenbrock23())
 
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         (idx1 == 1 && idx0 == 1) && @test sol[demux1x4.d.val] == sol[demux1x4.y0.val]
         (idx1 == 1 && idx0 == 2) && @test sol[demux1x4.d.val] == sol[demux1x4.y1.val]
         (idx1 == 2 && idx0 == 1) && @test sol[demux1x4.d.val] == sol[demux1x4.y2.val]
@@ -398,7 +400,7 @@ end
     prob = ODEProblem(sys, u0, (0, 1.5))
     sol = solve(prob, Rosenbrock23())
 
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[enc4x2.y0.val] == _or.(sol[input[4].d.val], sol[input[2].d.val])
     @test sol[enc4x2.y1.val] == _or.(sol[input[4].d.val], sol[input[3].d.val])
 
@@ -419,7 +421,7 @@ end
     prob = ODEProblem(sys, u0, (0, 1.5))
     sol = solve(prob, Rosenbrock23())
 
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[dec2x4.y0.val] ==
           _and.(_not.(sol[input[2].d.val]),
                 _not.(sol[input[1].d.val]))
@@ -450,7 +452,7 @@ end
         prob = ODEProblem(sys, u0, (0, 1.5))
         sol = solve(prob, Rosenbrock23())
 
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test ModelingToolkitStandardLibrary._and.(sol[and.x1.val], sol[and.x2.val]) ==
               sol[and.y.val]
     end

--- a/test/Magnetic/magnetic.jl
+++ b/test/Magnetic/magnetic.jl
@@ -4,6 +4,7 @@ import ModelingToolkitStandardLibrary.Electrical
 import ModelingToolkitStandardLibrary.Blocks
 import ModelingToolkitStandardLibrary.Magnetic
 using ModelingToolkit, OrdinaryDiffEq, Test
+using OrdinaryDiffEq: ReturnCode.Success
 # using Plots
 
 @parameters t
@@ -54,7 +55,7 @@ using ModelingToolkit, OrdinaryDiffEq, Test
     # Plots.plot(sol; vars=[r.i])
     # Plots.plot(sol; vars=[r_mFe.V_m, r_mFe.Phi])
 
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[r_mFe.Phi] == sol[r_mAirPar.Phi]
     @test all(sol[coil.port_p.Phi] + sol[r_mLeak.Phi] + sol[r_mAirPar.Phi] .== 0)
 end

--- a/test/Mechanical/rotational.jl
+++ b/test/Mechanical/rotational.jl
@@ -1,6 +1,8 @@
 using ModelingToolkitStandardLibrary.Mechanical.Rotational, ModelingToolkit, OrdinaryDiffEq,
       Test
 import ModelingToolkitStandardLibrary.Blocks
+using OrdinaryDiffEq: ReturnCode.Success
+
 # using Plots
 
 @parameters t
@@ -23,15 +25,15 @@ D = Differential(t)
 
     prob = ODEProblem(sys, Pair[], (0, 10.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
 
     prob = ODAEProblem(sys, Pair[], (0, 10.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
 
     prob = DAEProblem(sys, D.(states(sys)) .=> 0.0, Pair[], (0, 10.0))
     sol = solve(prob, DFBDF())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test all(sol[inertia1.w] .== 0)
     @test sol[inertia2.w][end]≈0 atol=1e-3 # all energy has dissipated
 
@@ -71,14 +73,14 @@ end
     prob = DAEProblem(sys, D.(states(sys)) .=> 0.0,
                       [D(D(inertia2.phi)) => 1.0; D.(states(model)) .=> 0.0], (0, 10.0))
     sol = solve(prob, DFBDF())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
 
     prob = ODAEProblem(sys, Pair[], (0, 1.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
 
     @test_skip begin
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         @test all(isapprox.(sol[inertia1.w], -sol[inertia2.w] * 2, atol = 1)) # exact opposite oscillation with smaller amplitude J2 = 2*J1
         @test_broken all(sol[torque.flange.tau] .== -sol[sine.output.u]) # torque source is equal to negative sine
     end
@@ -130,7 +132,7 @@ end
         sys = structural_simplify(model) #key 7 not found
         prob = ODAEProblem(sys, Pair[], (0, 1.0))
         sol = solve(prob, Rodas4())
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
     end
     # Plots.plot(sol; vars=[inertia2.w, inertia3.w])
 end
@@ -179,7 +181,7 @@ end
     prob = DAEProblem(sys, D.(states(sys)) .=> 0.0, Pair[], (0, 10.0))
 
     sol = solve(prob, DFBDF())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[angle_sensor.phi.u] == sol[inertia.flange_a.phi]
 
     # p1 = Plots.plot(sol; vars=[inertia.flange_a.phi, source.phi], title="Angular Position", labels=["Inertia" "Source"], ylabel="Angle in rad")
@@ -216,7 +218,7 @@ end
 
     prob = ODEProblem(sys, Pair[], (0, 10.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test all(sol[inertia1.w] .== 0)
     @test all(sol[inertia1.w] .== sol[speed_sensor.w.u])
     @test sol[inertia2.w][end]≈0 atol=1e-3 # all energy has dissipated
@@ -225,7 +227,7 @@ end
 
     prob = DAEProblem(sys, D.(states(sys)) .=> 0.0, Pair[], (0, 10.0))
     sol = solve(prob, DFBDF())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test all(sol[inertia1.w] .== 0)
     @test all(sol[inertia1.w] .== sol[speed_sensor.w.u])
     @test sol[inertia2.w][end]≈0 atol=1e-3 # all energy has dissipated

--- a/test/Thermal/demo.jl
+++ b/test/Thermal/demo.jl
@@ -1,4 +1,6 @@
 using ModelingToolkitStandardLibrary.Thermal, ModelingToolkit, OrdinaryDiffEq, Test
+using OrdinaryDiffEq: ReturnCode.Success
+
 @parameters t
 D = Differential(t)
 
@@ -22,5 +24,5 @@ D = Differential(t)
     sys = structural_simplify(model)
     prob = ODEProblem(sys, [mass1.der_T => 1.0, mass2.der_T => 1.0], (0, 3.0))
     sol = solve(prob, Tsit5())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
 end

--- a/test/Thermal/thermal.jl
+++ b/test/Thermal/thermal.jl
@@ -1,5 +1,7 @@
 using ModelingToolkitStandardLibrary.Thermal, ModelingToolkit, OrdinaryDiffEq, Test
 using ModelingToolkitStandardLibrary.Blocks: Constant, Step
+using OrdinaryDiffEq: ReturnCode.Success
+
 @parameters t
 D = Differential(t)
 
@@ -29,7 +31,7 @@ D = Differential(t)
 
     # Check if Relative temperature sensor reads the temperature of heat capacitor
     # when connected to a thermal conductor and a fixed temperature source
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[reltem_sensor.T] + sol[tem_src.port.T] == sol[mass1.T] + sol[th_conductor.dT]
 
     @info "Building a two-body system..."
@@ -49,7 +51,7 @@ D = Differential(t)
     prob = ODEProblem(sys, u0, (0, 3.0))
     sol = solve(prob, Tsit5())
 
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     m1, m2 = sol.u[end]
     @test m1≈m2 atol=1e-1
     mass_T = reduce(hcat, sol.u)
@@ -85,7 +87,7 @@ end
     prob = ODEProblem(sys, u0, (0, 3.0))
     sol = solve(prob, Tsit5())
 
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[th_conductor.dT] .* G == sol[th_conductor.Q_flow]
     @test sol[th_conductor.Q_flow] ≈ sol[hf_sensor1.Q_flow] + sol[flow_src.port.Q_flow]
 
@@ -119,7 +121,7 @@ end
 
     # Heat-flow-rate is equal in magnitude
     # and opposite in direction
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[gas.Q_flow] + sol[coolant.Q_flow] == zeros(length(sol))
 end
 
@@ -157,7 +159,7 @@ end
     prob = ODEProblem(sys, u0, (0, 3.0))
     sol = solve(prob, Rodas4())
 
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[dissipator.dT] == sol[radiator.port_a.T] - sol[radiator.port_b.T]
     rad_Q_flow = G * σ * (T_gas^4 - T_coolant^4)
     @test sol[radiator.Q_flow] == fill(rad_Q_flow, length(sol[radiator.Q_flow]))
@@ -190,7 +192,7 @@ end
     prob = ODEProblem(sys, u0, (0, 3.0))
     sol = solve(prob, Rodas4())
 
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[collector.port_b.Q_flow] + sol[collector.port_a1.Q_flow] +
           sol[collector.port_a2.Q_flow] ==
           zeros(length(sol[collector.port_b.Q_flow]))
@@ -237,7 +239,7 @@ end
     sol = solve(prob, Rodas4())
 
     # plot(sol; vars=[T_winding.T, T_core.T])
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[T_winding.T] == sol[winding.T]
     @test sol[T_core.T] == sol[core.T]
     @test sol[-core.port.Q_flow] ==

--- a/test/chua_circuit.jl
+++ b/test/chua_circuit.jl
@@ -2,6 +2,7 @@ using ModelingToolkit
 using ModelingToolkitStandardLibrary.Electrical
 using ModelingToolkitStandardLibrary.Electrical: OnePort
 using OrdinaryDiffEq
+using OrdinaryDiffEq: ReturnCode.Success
 using IfElse: ifelse
 
 @testset "Chua Circuit" begin
@@ -46,5 +47,5 @@ using IfElse: ifelse
     prob = ODEProblem(sys, Pair[], (0, 5e4), saveat = 0.01)
     sol = solve(prob, Rodas4())
 
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
 end

--- a/test/demo.jl
+++ b/test/demo.jl
@@ -1,5 +1,6 @@
 using ModelingToolkitStandardLibrary.Electrical, ModelingToolkit, OrdinaryDiffEq #, Plots
 using ModelingToolkitStandardLibrary.Blocks: Constant
+using OrdinaryDiffEq: ReturnCode.Success
 using Test
 
 @testset "RC demo" begin
@@ -24,6 +25,6 @@ using Test
     prob = ODAEProblem(sys, Pair[], (0, 10.0))
     sol = solve(prob, Tsit5())
     #plot(sol)
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test isapprox(sol[capacitor.v][end], V, atol = 1e-2)
 end

--- a/test/multi_domain.jl
+++ b/test/multi_domain.jl
@@ -5,6 +5,7 @@ using ModelingToolkitStandardLibrary.Blocks
 using ModelingToolkitStandardLibrary.Thermal
 import ModelingToolkitStandardLibrary
 using ModelingToolkit, OrdinaryDiffEq, Test
+using OrdinaryDiffEq: ReturnCode.Success
 # using Plots
 
 @parameters t
@@ -59,7 +60,7 @@ D = Differential(t)
     @test_broken prob = ODAEProblem(sys, Pair[], (0, 6.0))
     @test_skip begin
         sol = solve(prob, Rodas4())
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         # EMF equations
         @test -0.5 .* sol[emf.i] == sol[emf.flange.tau]
         @test sol[emf.v] == 0.5 .* sol[emf.w]
@@ -75,7 +76,7 @@ D = Differential(t)
 
     prob = DAEProblem(sys, D.(states(sys)) .=> 0.0, Pair[], (0, 6.0))
     sol = solve(prob, DFBDF())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     # EMF equations
     @test -0.5 .* sol[emf.i] == sol[emf.flange.tau]
     @test sol[emf.v] == 0.5 .* sol[emf.w]
@@ -147,7 +148,7 @@ end
     @test_skip begin
         sol = solve(prob, Rodas4())
 
-        @test sol.retcode == :Success
+        @test sol.retcode == Success
         # EMF equations
         @test -0.5 .* sol[emf.i] == sol[emf.flange.tau]
         @test sol[emf.v] == 0.5 .* sol[emf.w]
@@ -161,14 +162,14 @@ end
         @test sol[inertia.w][idx_t]≈(dc_gain * [V_step; -tau_L_step])[2] rtol=1e-3
         @test sol[emf.i][idx_t]≈(dc_gain * [V_step; -tau_L_step])[1] rtol=1e-3
 
-        # 
+        #
         @test all(sol[inertia.w] .== sol[speed_sensor.w.u])
     end
 
     prob = DAEProblem(sys, D.(states(sys)) .=> 0.0, Pair[], (0, 6.0))
     sol = solve(prob, DFBDF())
 
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     # EMF equations
     @test -0.5 .* sol[emf.i] == sol[emf.flange.tau]
     @test sol[emf.v] == 0.5 .* sol[emf.w]
@@ -180,7 +181,7 @@ end
     idx_t = findfirst(sol.t .> 5.5)
     @test sol[inertia.w][idx_t]≈(dc_gain * [V_step; -tau_L_step])[2] rtol=1e-3
     @test sol[emf.i][idx_t]≈(dc_gain * [V_step; -tau_L_step])[1] rtol=1e-3
-    # 
+    #
     @test all(sol[inertia.w] .== sol[speed_sensor.w.u])
 end
 
@@ -210,6 +211,6 @@ end
 
     prob = ODEProblem(sys, Pair[], (0, 6.0))
     sol = solve(prob, Rodas4())
-    @test sol.retcode == :Success
+    @test sol.retcode == Success
     @test sol[source.v * source.i] == -sol[env.port.Q_flow]
 end


### PR DESCRIPTION
Refactor the return code from `:Success` -> `ReturnCode.Success`

Fixes: https://github.com/SciML/ModelingToolkitStandardLibrary.jl/actions/runs/4205971179/jobs/7298817614#step:6:456