### PR TITLE
Add Translational library similar to MSL

### DIFF
--- a/src/Mechanical/Mechanical.jl
+++ b/src/Mechanical/Mechanical.jl
@@ -8,6 +8,7 @@ using ModelingToolkit
 include("Rotational/Rotational.jl")
 include("Translational/Translational.jl")
 include("TranslationalPosition/TranslationalPosition.jl")
+include("TranslationalModelica/TranslationalModelica.jl")
 include("MultiBody2D/MultiBody2D.jl")
 
 end

--- a/src/Mechanical/Rotational/Rotational.jl
+++ b/src/Mechanical/Rotational/Rotational.jl
@@ -15,7 +15,7 @@ include("utils.jl")
 export Fixed, Inertia, Spring, Damper, IdealGear, RotationalFriction
 include("components.jl")
 
-export Torque, Speed
+export Torque, ConstantTorque, Speed
 include("sources.jl")
 
 export AngleSensor, SpeedSensor, TorqueSensor, RelSpeedSensor

--- a/src/Mechanical/Rotational/sources.jl
+++ b/src/Mechanical/Rotational/sources.jl
@@ -1,12 +1,13 @@
 
 function PartialTorque(; name, use_support = false)
-  @named partial_element = PartialElementaryOneFlangeAndSupport2(use_support = use_support)
-  @unpack flange, phi_support = partial_element
-  @variables phi(t) [description = "Angle of flange with respect to support (= flange.phi - support.phi)"]
-  eqs = [phi ~ flange.phi - phi_support]
-  return extend(ODESystem(eqs, t; name = name), partial_element)
+    @named partial_element = PartialElementaryOneFlangeAndSupport2(use_support = use_support)
+    @unpack flange, phi_support = partial_element
+    @variables phi(t) [
+        description = "Angle of flange with respect to support (= flange.phi - support.phi)",
+    ]
+    eqs = [phi ~ flange.phi - phi_support]
+    return extend(ODESystem(eqs, t; name = name), partial_element)
 end
-
 
 """
     Torque(; name, use_support=false) 
@@ -34,21 +35,20 @@ function Torque(; name, use_support = false)
     return extend(ODESystem(eqs, t, [], []; name = name, systems = [tau]), partial_element)
 end
 
-
-
 function ConstantTorque(; name, tau_constant, use_support = false)
-  # NOTE: The use_support option is not specified for modelica ConstantTorque and defaults to false in the definition of PartialElementaryOneFlangeAndSupport2. If we do not set it to true, we will get a structurally singular system, and in the comment attached to the phi variable, they mention "flange.phi - support.phi", indicating that the support is used. 
-  @named partial_element = PartialTorque(; use_support)
-  @unpack flange, phi = partial_element
-  @parameters tau_constant=tau_constant [description = "Constant torque (if negative, torque is acting as load in positive direction of rotation)"]
-  @variables tau(t) [description = "Accelerating torque acting at flange (= -flange.tau)"]
-  @variables w(t) [description = "Angular velocity of flange with respect to support (= der(phi))"]
-  eqs = [
-    w ~ D(phi)
-    tau ~ -flange.tau
-    tau ~ tau_constant
-  ]
-  return extend(ODESystem(eqs, t; name = name), partial_element)
+    @named partial_element = PartialTorque(; use_support)
+    @unpack flange, phi = partial_element
+    @parameters tau_constant=tau_constant [
+        description = "Constant torque (if negative, torque is acting as load in positive direction of rotation)",
+    ]
+    @variables tau(t) [description = "Accelerating torque acting at flange (= -flange.tau)"]
+    @variables w(t) [
+        description = "Angular velocity of flange with respect to support (= der(phi))",
+    ]
+    eqs = [w ~ D(phi)
+           tau ~ -flange.tau
+           tau ~ tau_constant]
+    return extend(ODESystem(eqs, t; name = name), partial_element)
 end
 
 """

--- a/src/Mechanical/Rotational/sources.jl
+++ b/src/Mechanical/Rotational/sources.jl
@@ -16,7 +16,7 @@ Input signal acting as external torque on a flange
 
 # States:
 
-  - `phi_support(t)`: [`rad`] Absolute angle of support flange"
+  - `phi_support(t)`: [`rad`] Absolute angle of support flange
 
 # Connectors:
 
@@ -35,6 +35,24 @@ function Torque(; name, use_support = false)
     return extend(ODESystem(eqs, t, [], []; name = name, systems = [tau]), partial_element)
 end
 
+"""
+    ConstantTorque(; name, tau_constant, use_support = false)
+
+Constant torque source
+
+# State variables:
+  
+- `phi_support(t)`: [`rad`] Absolute angle of support flange, only available if `use_support = true`
+- `tau`: Accelerating torque acting at flange (= -flange.tau)
+- `w`: Angular velocity of flange with respect to support (= der(phi))
+
+# Connectors:
+- `flange` [Flange](@ref)
+
+# Arguments:
+- `tau_constant`: The constant torque applied by the source
+- `use_support`: Whether or not an internal support flange is added, defaults to false.
+"""
 function ConstantTorque(; name, tau_constant, use_support = false)
     @named partial_element = PartialTorque(; use_support)
     @unpack flange, phi = partial_element

--- a/src/Mechanical/Rotational/utils.jl
+++ b/src/Mechanical/Rotational/utils.jl
@@ -18,26 +18,26 @@ Base.@doc """
     extend(ODESystem(Equation[], t, [], [], name = name), flange)
 end
 
-Base.@doc """
-    InternalSupport(;name, tau)
+# Base.@doc """
+#     InternalSupport(;name, tau)
 
-1-dim. rotational flange of a shaft.
+# 1-dim. rotational flange of a shaft.
 
-- `tau`: External support torque (must be computed via torque balance in model where InternalSupport is used; = flange.tau)
+# - `tau`: External support torque (must be computed via torque balance in model where InternalSupport is used; = flange.tau)
 
-# States:
-- `phi(t)`: [`rad`] Absolute rotation angle of flange
-- `tau(t)`: [`N.m`] Cut torque in the flange
-""" Flange
+# # States:
+# - `phi(t)`: [`rad`] Absolute rotation angle of flange
+# - `tau(t)`: [`N.m`] Cut torque in the flange
+# """ Flange
 
-@connector function InternalSupport(; name, tau)
-    @named flange = Flange()
-    @variables phi(t)=0 [description = "Rotation angle of support $name"]
-    # tau(t), [connect = Flow, description = "Cut torque in support $name"],)
-    equations = [flange.tau ~ tau
-                 flange.phi ~ phi]
-    ODESystem(equations, t, [phi], [], name = name, systems = [flange]) # NOTE: tau not included since it belongs elsewhere
-end
+# @connector function InternalSupport(; name, tau)
+#     @named flange = Flange()
+#     @variables phi(t)=0 [description = "Rotation angle of support $name"]
+#     # tau(t), [connect = Flow, description = "Cut torque in support $name"],)
+#     equations = [flange.tau ~ tau
+#                  flange.phi ~ phi]
+#     ODESystem(equations, t, [phi], [], name = name, systems = [flange]) # NOTE: tau not included since it belongs elsewhere
+# end
 
 Base.@doc """
     Support(;name)

--- a/src/Mechanical/Rotational/utils.jl
+++ b/src/Mechanical/Rotational/utils.jl
@@ -39,7 +39,7 @@ Base.@doc """
         flange.tau ~ tau
         flange.phi ~ phi
     ]
-    ODESystem(equations, t, name = name, systems=[flange])
+    ODESystem(equations, t, [phi], [], name = name, systems=[flange]) # NOTE: tau not included since it belongs elsewhere
 end
 
 Base.@doc """

--- a/src/Mechanical/Rotational/utils.jl
+++ b/src/Mechanical/Rotational/utils.jl
@@ -18,7 +18,6 @@ Base.@doc """
     extend(ODESystem(Equation[], t, [], [], name = name), flange)
 end
 
-
 Base.@doc """
     InternalSupport(;name, tau)
 
@@ -35,11 +34,9 @@ Base.@doc """
     @named flange = Flange()
     @variables phi(t)=0 [description = "Rotation angle of support $name"]
     # tau(t), [connect = Flow, description = "Cut torque in support $name"],)
-    equations = [
-        flange.tau ~ tau
-        flange.phi ~ phi
-    ]
-    ODESystem(equations, t, [phi], [], name = name, systems=[flange]) # NOTE: tau not included since it belongs elsewhere
+    equations = [flange.tau ~ tau
+                 flange.phi ~ phi]
+    ODESystem(equations, t, [phi], [], name = name, systems = [flange]) # NOTE: tau not included since it belongs elsewhere
 end
 
 Base.@doc """

--- a/src/Mechanical/Rotational/utils.jl
+++ b/src/Mechanical/Rotational/utils.jl
@@ -4,7 +4,7 @@
     ODESystem(Equation[], t, sts, [], name = name, defaults = Dict(phi => 0.0, tau => 0.0))
 end
 Base.@doc """
-    Flange(;name)
+    Support(;name)
 
 1-dim. rotational flange of a shaft.
 
@@ -14,10 +14,34 @@ Base.@doc """
 """ Flange
 
 @connector function Support(; name)
-    sts = @variables(phi(t), [description = "Rotation angle of support $name"],
-                     tau(t), [connect = Flow, description = "Cut torque in support $name"],)
-    ODESystem(Equation[], t, sts, [], name = name, defaults = Dict(phi => 0.0, tau => 0.0))
+    @named flange = Flange()
+    extend(ODESystem(Equation[], t, [], [], name = name), flange)
 end
+
+
+Base.@doc """
+    InternalSupport(;name, tau)
+
+1-dim. rotational flange of a shaft.
+
+- `tau`: External support torque (must be computed via torque balance in model where InternalSupport is used; = flange.tau)
+
+# States:
+- `phi(t)`: [`rad`] Absolute rotation angle of flange
+- `tau(t)`: [`N.m`] Cut torque in the flange
+""" Flange
+
+@connector function InternalSupport(; name, tau)
+    @named flange = Flange()
+    @variables phi(t)=0 [description = "Rotation angle of support $name"]
+    # tau(t), [connect = Flow, description = "Cut torque in support $name"],)
+    equations = [
+        flange.tau ~ tau
+        flange.phi ~ phi
+    ]
+    ODESystem(equations, t, name = name, systems=[flange])
+end
+
 Base.@doc """
     Support(;name)
 

--- a/src/Mechanical/TranslationalModelica/TranslationalModelica.jl
+++ b/src/Mechanical/TranslationalModelica/TranslationalModelica.jl
@@ -1,0 +1,21 @@
+"""
+Library to model 1-dimensional, translational mechanical components.
+"""
+module TranslationalModelica
+
+using ModelingToolkit, Symbolics, IfElse
+using ...Blocks: RealInput, RealOutput
+
+@parameters t
+D = Differential(t)
+
+export Flange
+include("utils.jl")
+
+export Fixed, Mass, Spring, Damper, IdealGear
+include("components.jl")
+
+export Force
+include("sources.jl")
+
+end

--- a/src/Mechanical/TranslationalModelica/components.jl
+++ b/src/Mechanical/TranslationalModelica/components.jl
@@ -44,19 +44,16 @@ Sliding mass with inertia
   - `flange: 1-dim. translational flange of mass`
 """
 function Mass(m; name, s0 = 0.0, v0 = 0.0)
-    @named pr = PartialRigid(; L=0, s0)
+    @named pr = PartialRigid(; L = 0, s0)
     @unpack flange_a, flange_b, s = pr
-    @parameters m = m [description = "Mass of sliding mass [kg]"]
+    @parameters m=m [description = "Mass of sliding mass [kg]"]
     @variables v(t)=v0 [description = "Absolute linear velocity of sliding mass [m/s]"]
     @variables a(t)=0 [description = "Absolute linear acceleration of sliding mass [m/s^2]"]
-    eqs = [
-        v ~ D(s)
-        a ~ D(v)
-        m*a ~ flange_a.f + flange_b.f
-    ]
+    eqs = [v ~ D(s)
+           a ~ D(v)
+           m * a ~ flange_a.f + flange_b.f]
     return extend(ODESystem(eqs, t; name), pr)
 end
-
 
 """
     Spring(c; name, s_rel0=0)
@@ -76,10 +73,10 @@ Linear 1D translational spring
 function Spring(c; name, s_rel0 = 0)
     @named pc = PartialCompliant()
     @unpack flange_a, flange_b, s_rel, f = pc
-    @parameters c = c [description = "Spring constant [N/m]"]
-    @parameters s_rel0 = s_rel0 [description = "Unstretched spring length [m]"]
+    @parameters c=c [description = "Spring constant [N/m]"]
+    @parameters s_rel0=s_rel0 [description = "Unstretched spring length [m]"]
 
-    eqs = [f ~ c*(s_rel - s_rel0)]
+    eqs = [f ~ c * (s_rel - s_rel0)]
     return extend(ODESystem(eqs, t; name), pc)
 end
 
@@ -98,10 +95,10 @@ Linear 1D translational damper
   - `flange_b: 1-dim. translational flange on opposite side of damper`
 """
 function Damper(d; name)
-  @named pc = PartialCompliantWithRelativeStates()
-  @unpack flange_a, flange_b, v_rel, f = pc
-  @parameters d = d [description = "Damping constant [Ns/m]"]
-  @variables lossPower(t) = 0 [description = "Power dissipated by the damper [W]"]
-  eqs = [f ~ d*v_rel; lossPower ~ f*v_rel]
-  return extend(ODESystem(eqs, t; name), pc)
+    @named pc = PartialCompliantWithRelativeStates()
+    @unpack flange_a, flange_b, v_rel, f = pc
+    @parameters d=d [description = "Damping constant [Ns/m]"]
+    @variables lossPower(t)=0 [description = "Power dissipated by the damper [W]"]
+    eqs = [f ~ d * v_rel; lossPower ~ f * v_rel]
+    return extend(ODESystem(eqs, t; name), pc)
 end

--- a/src/Mechanical/TranslationalModelica/components.jl
+++ b/src/Mechanical/TranslationalModelica/components.jl
@@ -1,0 +1,107 @@
+"""
+    Fixed(;name, s0=0.0)
+
+Flange fixed in housing at a given position.
+
+# Parameters:
+
+  - `s0`: [m] Fixed offset position of housing
+
+# Connectors:
+
+  - `flange: 1-dim. translational flange`
+"""
+function Fixed(; name, s0 = 0.0)
+    pars = @parameters s0 = s0
+    vars = []
+
+    @named flange = Flange()
+
+    eqs = [flange.s ~ s0]
+
+    return compose(ODESystem(eqs, t, vars, pars; name = name, defaults = [flange.s => s0]),
+                   flange)
+end
+
+"""
+    Mass(; name, m, s0 = 0.0, v0 = 0.0)
+
+Sliding mass with inertia
+
+# Parameters:
+
+  - `m`: [kg] Mass of sliding mass
+  - `s0`: [m] Initial value of absolute position of sliding mass
+  - `v0`: [m/s] Initial value of absolute linear velocity of sliding mass
+
+# States:
+
+  - `s`: [m] Absolute position of sliding mass
+  - `v`: [m/s] Absolute linear velocity of sliding mass (= D(s))
+
+# Connectors:
+
+  - `flange: 1-dim. translational flange of mass`
+"""
+function Mass(m; name, s0 = 0.0, v0 = 0.0)
+    @named pr = PartialRigid(; L=0, s0)
+    @unpack flange_a, flange_b, s = pr
+    @parameters m = m [description = "Mass of sliding mass [kg]"]
+    @variables v(t)=v0 [description = "Absolute linear velocity of sliding mass [m/s]"]
+    @variables a(t)=0 [description = "Absolute linear acceleration of sliding mass [m/s^2]"]
+    eqs = [
+        v ~ D(s)
+        a ~ D(v)
+        m*a ~ flange_a.f + flange_b.f
+    ]
+    return extend(ODESystem(eqs, t; name), pr)
+end
+
+
+"""
+    Spring(c; name, s_rel0=0)
+
+Linear 1D translational spring
+
+# Parameters:
+
+  - `c`: [N/m] Spring constant
+  - `s_rel0`: Unstretched spring length
+
+# Connectors:
+
+  - `flange_a: 1-dim. translational flange on one side of spring`
+  - `flange_b: 1-dim. translational flange on opposite side of spring` #default function
+"""
+function Spring(c; name, s_rel0 = 0)
+    @named pc = PartialCompliant()
+    @unpack flange_a, flange_b, s_rel, f = pc
+    @parameters c = c [description = "Spring constant [N/m]"]
+    @parameters s_rel0 = s_rel0 [description = "Unstretched spring length [m]"]
+
+    eqs = [f ~ c*(s_rel - s_rel0)]
+    return extend(ODESystem(eqs, t; name), pc)
+end
+
+"""
+    Damper(d; name)
+
+Linear 1D translational damper
+
+# Parameters:
+
+  - `d`: [N.s/m] Damping constant
+
+# Connectors:
+
+  - `flange_a: 1-dim. translational flange on one side of damper`
+  - `flange_b: 1-dim. translational flange on opposite side of damper`
+"""
+function Damper(d; name)
+  @named pc = PartialCompliantWithRelativeStates()
+  @unpack flange_a, flange_b, v_rel, f = pc
+  @parameters d = d [description = "Damping constant [Ns/m]"]
+  @variables lossPower(t) = 0 [description = "Power dissipated by the damper [W]"]
+  eqs = [f ~ d*v_rel; lossPower ~ f*v_rel]
+  return extend(ODESystem(eqs, t; name), pc)
+end

--- a/src/Mechanical/TranslationalModelica/sources.jl
+++ b/src/Mechanical/TranslationalModelica/sources.jl
@@ -1,0 +1,12 @@
+"""
+    Force(;name) 
+
+Input signal acting as external force on a flange
+"""
+function Force(; name, use_support = false)
+    @named partial_element = PartialElementaryOneFlangeAndSupport2(use_support = use_support)
+    @unpack flange = partial_element
+    @named f = RealInput() # Accelerating force acting at flange (= -flange.tau)
+    eqs = [flange.f ~ -f.u]
+    return extend(ODESystem(eqs, t, [], []; name = name, systems = [f]), partial_element)
+end

--- a/src/Mechanical/TranslationalModelica/utils.jl
+++ b/src/Mechanical/TranslationalModelica/utils.jl
@@ -1,0 +1,164 @@
+@connector function Flange(; name)
+    vars = @variables begin
+        s(t)
+        f(t), [connect = Flow]
+    end
+    ODESystem(Equation[], t, vars, [], name = name, defaults = Dict(f => 0.0))
+end
+Base.@doc """
+    Flange(;name)
+
+1-dim. translational flange.
+
+# States:
+- `s`: [m] Absolute position of flange
+- `f`: [N] Cut force into the flange
+""" Flange
+
+@connector function Support(; name)
+    @named flange = Flange()
+    extend(ODESystem(Equation[], t, name = name), flange)
+end
+Base.@doc """
+    Support(;name)
+
+Support/housing 1-dim. translational flange.
+
+# States:
+- `s`: [m] Absolute position of the support/housing
+- `f`: [N] Cut force into the flange
+""" Support
+
+
+function PartialTwoFlanges(; name)
+    @named flange_a = Flange() # (left) driving flange (flange axis directed into cut plane, e. g. from left to right)
+    @named flange_b = Flange() # (right) driven flange (flange axis directed out of cut plane)
+    compose(ODESystem([], t; name), flange_a, flange_b)
+end
+
+"""
+    PartialCompliant(;name, s_rel_start=0.0, f_start=0.0)
+
+Partial model for the compliant connection of two translational 1-dim. flanges.
+
+# Parameters:
+
+  - `s_rel_start`: [m] Initial relative distance between the flanges
+  - `f_start`: [N] Initial force between flanges
+
+# States:
+
+  - `s_rel`: [m] Relative distance (= flange_b.s - flange_a.s)
+  - `f`: [N] Force between flanges (= flange_b.f)
+"""
+function PartialCompliant(; name, s_rel_start = 0.0, f_start = 0.0)
+    @named pt = PartialTwoFlanges()
+    @unpack flange_a, flange_b = pt
+    @variables s_rel(t) = s_rel_start [description = "Relative distance between flanges flange_b.s - flange_a.s"]
+    @variables f(t) = f_start [description = "Force between flanges (positive in direction of flange axis R)"]
+
+    eqs = [s_rel ~ flange_b.s - flange_a.s
+           flange_b.f ~ +f
+           flange_a.f ~ -f]
+    return extend(ODESystem(eqs, t; name = name), pt)
+end
+
+"""
+    PartialCompliantWithRelativeStates(;name, s_rel_start=0.0, v_rel_start=0.0, f_start=0.0)
+
+Partial model for the compliant connection of two translational 1-dim. flanges.
+
+# Parameters:
+
+  - `s_rel_start`: [m] Initial relative distance
+  - `v_rel_start`: [m/s] Initial relative linear velocity (= der(s_rel))
+
+# States:
+
+  - `s_rel`: [m] Relative distance (= flange_b.phi - flange_a.phi)
+  - `v_rel`: [m/s] Relative linear velocity (= der(s_rel))
+  - `f`: [N] Force between flanges (= flange_b.f)
+"""
+function PartialCompliantWithRelativeStates(; name, s_rel_start = 0, v_rel_start = 0, f_start = 0)
+    pt = PartialTwoFlanges()
+    @unpack flange_a, flange_b = pt
+    @variables s_rel(t) = s_rel_start [description = "Relative distance between flanges flange_b.s - flange_a.s"]
+    @variables v_rel(t) = v_rel_start [description = "Relative linear velocity (= D(s_rel))"]
+    @variables f(t) = f_start [description = "Forces between flanges (= flange_b.f)"]
+
+    eqs = [s_rel ~ flange_b.s - flange_a.s
+            v_rel ~ D(s_rel)
+            flange_b.f ~ f
+            flange_a.f ~ -f]
+    return extend(ODESystem(eqs, t; name = name), pt)
+end
+
+"""
+    PartialElementaryOneFlangeAndSupport2(;name, use_support=false)
+
+Partial model for a component with one translational 1-dim. shaft flange and a support used for textual modeling, i.e., for elementary models
+
+# Parameters:
+
+  - `use_support`: If support flange enabled, otherwise implicitly grounded
+
+# States:
+
+  - `s_support`: [m] Absolute position of support flange"
+"""
+function PartialElementaryOneFlangeAndSupport2(; name, use_support = false)
+    @named flange = Flange()
+    @variables s_support(t) [description = "Absolute position of support flange"]
+    @variables s(t) [description = "Distance between flange and support (= flange.s - support.s)"]
+    eqs = [s ~ flange.s - s_support]
+    if use_support
+        @named support = Support()
+        push!(eqs, support.f ~ -flange.f)
+        compose(ODESystem(eqs, t; name = name), flange, support)
+    else
+        push!(eqs, s_support ~ 0)
+        compose(ODESystem(eqs, t; name = name), flange)
+    end
+end
+
+"""
+    PartialElementaryTwoFlangesAndSupport2(;name, use_support=false)
+
+Partial model for a component with two translational 1-dim. flanges and a support used for textual modeling, i.e., for elementary models
+
+# Parameters:
+
+  - `use_support`: If support flange enabled, otherwise implicitly grounded
+
+# States:
+
+  - `s_support`: [m] Absolute position of support flange"
+"""
+function PartialElementaryTwoFlangesAndSupport2(; name, use_support = false)
+    @named flange = Flange()
+
+    @variables s_a(t) [description = "Distance between left flange and support"]
+    @variables s_b(t) [description = "Distance between right flange and support"]
+    @variables s_support(t) [description = "Absolute position of support flange"]
+
+    eqs = [s_a ~ flange_a.s - s_support
+           s_b ~ flange_b.s - s_support]
+    if use_support
+        @named support = Support()
+        push!(eqs, support.f ~ -flange_a.f - flange_b.f)
+        compose(ODESystem(eqs, t; name = name), flange, support)
+    else
+        push!(eqs, s_support ~ 0)
+        compose(ODESystem(eqs, t; name = name), flange)
+    end
+end
+
+function PartialRigid(; name, L=0, s0=0)
+    ptf = PartialTwoFlanges()
+    @unpack flange_a, flange_b = ptf
+    @variables s(t) = s0 [description="Absolute position of center of component (s = flange_a.s + L/2 = flange_b.s - L/2)"]
+    @parameters L(t) = L [description="Length of component, from left flange to right flange (= flange_b.s - flange_a.s)"]
+    eqs = [flange_a.s ~ s - L/2
+    flange_b.s ~ s + L/2]
+    return extend(ODESystem(eqs, t; name = name), ptf)
+end

--- a/src/Mechanical/TranslationalModelica/utils.jl
+++ b/src/Mechanical/TranslationalModelica/utils.jl
@@ -29,7 +29,6 @@ Support/housing 1-dim. translational flange.
 - `f`: [N] Cut force into the flange
 """ Support
 
-
 function PartialTwoFlanges(; name)
     @named flange_a = Flange() # (left) driving flange (flange axis directed into cut plane, e. g. from left to right)
     @named flange_b = Flange() # (right) driven flange (flange axis directed out of cut plane)
@@ -54,8 +53,12 @@ Partial model for the compliant connection of two translational 1-dim. flanges.
 function PartialCompliant(; name, s_rel_start = 0.0, f_start = 0.0)
     @named pt = PartialTwoFlanges()
     @unpack flange_a, flange_b = pt
-    @variables s_rel(t) = s_rel_start [description = "Relative distance between flanges flange_b.s - flange_a.s"]
-    @variables f(t) = f_start [description = "Force between flanges (positive in direction of flange axis R)"]
+    @variables s_rel(t)=s_rel_start [
+        description = "Relative distance between flanges flange_b.s - flange_a.s",
+    ]
+    @variables f(t)=f_start [
+        description = "Force between flanges (positive in direction of flange axis R)",
+    ]
 
     eqs = [s_rel ~ flange_b.s - flange_a.s
            flange_b.f ~ +f
@@ -79,17 +82,20 @@ Partial model for the compliant connection of two translational 1-dim. flanges.
   - `v_rel`: [m/s] Relative linear velocity (= der(s_rel))
   - `f`: [N] Force between flanges (= flange_b.f)
 """
-function PartialCompliantWithRelativeStates(; name, s_rel_start = 0, v_rel_start = 0, f_start = 0)
+function PartialCompliantWithRelativeStates(; name, s_rel_start = 0, v_rel_start = 0,
+                                            f_start = 0)
     @named pt = PartialTwoFlanges()
     @unpack flange_a, flange_b = pt
-    @variables s_rel(t) = s_rel_start [description = "Relative distance between flanges flange_b.s - flange_a.s"]
-    @variables v_rel(t) = v_rel_start [description = "Relative linear velocity (= D(s_rel))"]
-    @variables f(t) = f_start [description = "Forces between flanges (= flange_b.f)"]
+    @variables s_rel(t)=s_rel_start [
+        description = "Relative distance between flanges flange_b.s - flange_a.s",
+    ]
+    @variables v_rel(t)=v_rel_start [description = "Relative linear velocity (= D(s_rel))"]
+    @variables f(t)=f_start [description = "Forces between flanges (= flange_b.f)"]
 
     eqs = [s_rel ~ flange_b.s - flange_a.s
-            v_rel ~ D(s_rel)
-            flange_b.f ~ f
-            flange_a.f ~ -f]
+           v_rel ~ D(s_rel)
+           flange_b.f ~ f
+           flange_a.f ~ -f]
     return extend(ODESystem(eqs, t; name = name), pt)
 end
 
@@ -109,7 +115,9 @@ Partial model for a component with one translational 1-dim. shaft flange and a s
 function PartialElementaryOneFlangeAndSupport2(; name, use_support = false)
     @named flange = Flange()
     @variables s_support(t) [description = "Absolute position of support flange"]
-    @variables s(t) [description = "Distance between flange and support (= flange.s - support.s)"]
+    @variables s(t) [
+        description = "Distance between flange and support (= flange.s - support.s)",
+    ]
     eqs = [s ~ flange.s - s_support]
     if use_support
         @named support = Support()
@@ -153,12 +161,16 @@ function PartialElementaryTwoFlangesAndSupport2(; name, use_support = false)
     end
 end
 
-function PartialRigid(; name, L=0, s0=0)
+function PartialRigid(; name, L = 0, s0 = 0)
     @named ptf = PartialTwoFlanges()
     @unpack flange_a, flange_b = ptf
-    @variables s(t) = s0 [description="Absolute position of center of component (s = flange_a.s + L/2 = flange_b.s - L/2)"]
-    @parameters L(t) = L [description="Length of component, from left flange to right flange (= flange_b.s - flange_a.s)"]
-    eqs = [flange_a.s ~ s - L/2
-    flange_b.s ~ s + L/2]
+    @variables s(t)=s0 [
+        description = "Absolute position of center of component (s = flange_a.s + L/2 = flange_b.s - L/2)",
+    ]
+    @parameters L=L [
+        description = "Length of component, from left flange to right flange (= flange_b.s - flange_a.s)",
+    ]
+    eqs = [flange_a.s ~ s - L / 2
+           flange_b.s ~ s + L / 2]
     return extend(ODESystem(eqs, t; name = name), ptf)
 end

--- a/src/Mechanical/TranslationalModelica/utils.jl
+++ b/src/Mechanical/TranslationalModelica/utils.jl
@@ -80,7 +80,7 @@ Partial model for the compliant connection of two translational 1-dim. flanges.
   - `f`: [N] Force between flanges (= flange_b.f)
 """
 function PartialCompliantWithRelativeStates(; name, s_rel_start = 0, v_rel_start = 0, f_start = 0)
-    pt = PartialTwoFlanges()
+    @named pt = PartialTwoFlanges()
     @unpack flange_a, flange_b = pt
     @variables s_rel(t) = s_rel_start [description = "Relative distance between flanges flange_b.s - flange_a.s"]
     @variables v_rel(t) = v_rel_start [description = "Relative linear velocity (= D(s_rel))"]
@@ -154,7 +154,7 @@ function PartialElementaryTwoFlangesAndSupport2(; name, use_support = false)
 end
 
 function PartialRigid(; name, L=0, s0=0)
-    ptf = PartialTwoFlanges()
+    @named ptf = PartialTwoFlanges()
     @unpack flange_a, flange_b = ptf
     @variables s(t) = s0 [description="Absolute position of center of component (s = flange_a.s + L/2 = flange_b.s - L/2)"]
     @parameters L(t) = L [description="Length of component, from left flange to right flange (= flange_b.s - flange_a.s)"]

--- a/test/Mechanical/translational_modelica.jl
+++ b/test/Mechanical/translational_modelica.jl
@@ -1,0 +1,75 @@
+using ModelingToolkit, OrdinaryDiffEq, Test
+
+using ModelingToolkitStandardLibrary.Blocks
+import ModelingToolkitStandardLibrary.Mechanical.TranslationalModelica as TP
+
+@parameters t
+D = Differential(t)
+
+@testset "spring damper mass fixed" begin
+    @named damper = TP.Damper(1)
+
+    @named spring = TP.Spring(1; s_rel0 = 1)
+
+    @named mass = TP.Mass(1)
+
+    @named fixed = TP.Fixed(s0 = 1)
+
+
+    eqs = [connect(spring.flange_a, mass.flange_a, damper.flange_a)
+            connect(spring.flange_b, damper.flange_b, fixed.flange)]
+
+    @named model = ODESystem(eqs, t; systems = [fixed, mass, spring, damper])
+
+    sys = structural_simplify(model)
+
+    foreach(println, full_equations(sys))
+
+    prob = ODEProblem(sys, [], (0, 20.0), [])
+    sol = solve(prob, ImplicitMidpoint(), dt = 0.01)
+
+
+
+    @test sol[mass.v][1] == 1.0
+    @test sol[mass.v][end]≈0.0 atol=1e-4
+end
+
+@testset "driven spring damper mass" begin
+    @named damper = TP.Damper(d = 1, v_a_0 = 1, s_a_0 = 3, s_b_0 = 1)
+
+    @named spring = TP.Spring(k = 1, s_a_0 = 3, s_b_0 = 1, l = 1)
+
+    @named mass = TP.Mass(m = 1, v_0 = 1, s_0 = 3)
+
+    @named fixed = TP.Fixed(s_0 = 1)
+
+    @named force = TP.Force()
+
+    @named source = Sine(frequency = 3, amplitude = 2)
+
+    function simplify_and_solve(damping, spring, body, fixed, f, source)
+        eqs = [connect(f.f, source.output)
+               connect(f.flange, body.flange)
+               connect(spring.flange_a, body.flange, damping.flange_a)
+               connect(spring.flange_b, damping.flange_b, fixed.flange)]
+
+        @named model = ODESystem(eqs, t;
+                                 systems = [fixed, body, spring, damping, f, source])
+
+        sys = structural_simplify(model)
+
+        foreach(println, full_equations(sys))
+
+        prob = ODEProblem(sys, [], (0, 20.0), [])
+        sol = solve(prob, Rodas4())
+
+        return sol
+    end
+
+    solp = simplify_and_solve(damper, spring, mass, fixed, force, source)
+
+    lb, ub = extrema(sol(15:0.05:20, idxs = mass.v).u)
+    @test -lb≈ub atol=1e-2
+    @test -0.11 < lb < -0.1
+
+end

--- a/test/Mechanical/translational_modelica.jl
+++ b/test/Mechanical/translational_modelica.jl
@@ -11,13 +11,12 @@ D = Differential(t)
 
     @named spring = TP.Spring(1; s_rel0 = 1)
 
-    @named mass = TP.Mass(1)
+    @named mass = TP.Mass(1, v0 = 1)
 
     @named fixed = TP.Fixed(s0 = 1)
 
-
     eqs = [connect(spring.flange_a, mass.flange_a, damper.flange_a)
-            connect(spring.flange_b, damper.flange_b, fixed.flange)]
+           connect(spring.flange_b, damper.flange_b, fixed.flange)]
 
     @named model = ODESystem(eqs, t; systems = [fixed, mass, spring, damper])
 
@@ -28,48 +27,39 @@ D = Differential(t)
     prob = ODEProblem(sys, [], (0, 20.0), [])
     sol = solve(prob, ImplicitMidpoint(), dt = 0.01)
 
-
-
     @test sol[mass.v][1] == 1.0
     @test sol[mass.v][end]≈0.0 atol=1e-4
 end
 
 @testset "driven spring damper mass" begin
-    @named damper = TP.Damper(d = 1, v_a_0 = 1, s_a_0 = 3, s_b_0 = 1)
+    @named damper = TP.Damper(1)
 
-    @named spring = TP.Spring(k = 1, s_a_0 = 3, s_b_0 = 1, l = 1)
+    @named spring = TP.Spring(1; s_rel0 = 1)
 
-    @named mass = TP.Mass(m = 1, v_0 = 1, s_0 = 3)
+    @named mass = TP.Mass(1, v0 = 1)
 
-    @named fixed = TP.Fixed(s_0 = 1)
+    @named fixed = TP.Fixed(s0 = 1)
 
     @named force = TP.Force()
 
     @named source = Sine(frequency = 3, amplitude = 2)
 
-    function simplify_and_solve(damping, spring, body, fixed, f, source)
-        eqs = [connect(f.f, source.output)
-               connect(f.flange, body.flange)
-               connect(spring.flange_a, body.flange, damping.flange_a)
-               connect(spring.flange_b, damping.flange_b, fixed.flange)]
+    eqs = [connect(force.f, source.output)
+           connect(force.flange, mass.flange_a)
+           connect(spring.flange_a, mass.flange_b, damper.flange_a)
+           connect(spring.flange_b, damper.flange_b, fixed.flange)]
 
-        @named model = ODESystem(eqs, t;
-                                 systems = [fixed, body, spring, damping, f, source])
+    @named model = ODESystem(eqs, t;
+                             systems = [fixed, mass, spring, damper, force, source])
 
-        sys = structural_simplify(model)
+    sys = structural_simplify(model)
 
-        foreach(println, full_equations(sys))
+    foreach(println, full_equations(sys))
 
-        prob = ODEProblem(sys, [], (0, 20.0), [])
-        sol = solve(prob, Rodas4())
-
-        return sol
-    end
-
-    solp = simplify_and_solve(damper, spring, mass, fixed, force, source)
+    prob = ODEProblem(sys, [], (0, 20.0), [])
+    sol = solve(prob, Rodas4())
 
     lb, ub = extrema(sol(15:0.05:20, idxs = mass.v).u)
     @test -lb≈ub atol=1e-2
     @test -0.11 < lb < -0.1
-
 end


### PR DESCRIPTION
This PR adds a version of the `Mechanical.Translational` that is more similar to the modelica versions than the two existing `Mechanical.Translational` and `Mechanical.TranslationalPosition`. There are several strong motivations for staying closer to the modelica equivalents: 
The multibody library uses the Translational library, and any deviation increases the multibody implementation effort many fold, as well as making it much more likely that we introduce bugs in the process. A graphical user interface becomes similarly more difficult to implement when a translation step is required between the open standard and our implementation, for us to be able to reuse existing assets. Lastly, the burden on existing modelica users who want to transition increases if we change variable names and definitions in subtle ways, with no clear benefit. 

This implementation is quite a bit lighter weight than the current `TranslationalPosition` due to making use of partial models in the same way modelica does.