### PR TITLE
add symcheck macro

### DIFF
--- a/src/Blocks/Blocks.jl
+++ b/src/Blocks/Blocks.jl
@@ -4,7 +4,7 @@ The module `Blocks` contains common input-output components, referred to as bloc
 module Blocks
 using ModelingToolkit, Symbolics
 using IfElse: ifelse
-using ..ModelingToolkitStandardLibrary: @symcheck
+import ..@symcheck
 
 @parameters t
 D = Differential(t)

--- a/src/Blocks/Blocks.jl
+++ b/src/Blocks/Blocks.jl
@@ -4,6 +4,7 @@ The module `Blocks` contains common input-output components, referred to as bloc
 module Blocks
 using ModelingToolkit, Symbolics
 using IfElse: ifelse
+using ..ModelingToolkitStandardLibrary: @symcheck
 
 @parameters t
 D = Differential(t)

--- a/src/Blocks/continuous.jl
+++ b/src/Blocks/continuous.jl
@@ -52,7 +52,7 @@ A smaller `T` leads to a more ideal approximation of the derivative.
   - `output`
 """
 @component function Derivative(; name, k = 1, T, x_start = 0.0)
-    T > 0 || throw(ArgumentError("Time constant `T` has to be strictly positive"))
+    @symcheck T > 0 || throw(ArgumentError("Time constant `T` has to be strictly positive"))
     @named siso = SISO()
     @unpack u, y = siso
     sts = @variables x(t)=x_start [description = "State of Derivative $name"]
@@ -98,7 +98,7 @@ sT + 1 - k
 See also [`SecondOrder`](@ref)
 """
 @component function FirstOrder(; name, k = 1, T, x_start = 0.0, lowpass = true)
-    T > 0 || throw(ArgumentError("Time constant `T` has to be strictly positive"))
+    @symcheck T > 0 || throw(ArgumentError("Time constant `T` has to be strictly positive"))
     @named siso = SISO()
     @unpack u, y = siso
     sts = @variables x(t)=x_start [description = "State of FirstOrder filter $name"]
@@ -171,7 +171,7 @@ Textbook version of a PI-controller without actuator saturation and anti-windup 
 See also [`LimPI`](@ref)
 """
 @component function PI(; name, k = 1, T, x_start = 0.0)
-    T > 0 || throw(ArgumentError("Time constant `T` has to be strictly positive"))
+    @symcheck T > 0 || throw(ArgumentError("Time constant `T` has to be strictly positive"))
     @named err_input = RealInput() # control error
     @named ctr_output = RealOutput() # control signal
     @named gainPI = Gain(k)
@@ -282,9 +282,10 @@ Text-book version of a PI-controller with actuator saturation and anti-windup me
   - `ctr_output`
 """
 @component function LimPI(; name, k = 1, T, u_max, u_min = -u_max, Ta, x_start = 0.0)
-    Ta > 0 || throw(ArgumentError("Time constant `Ta` has to be strictly positive"))
-    T > 0 || throw(ArgumentError("Time constant `T` has to be strictly positive"))
-    u_max ≥ u_min || throw(ArgumentError("u_min must be smaller than u_max"))
+    @symcheck Ta > 0 ||
+              throw(ArgumentError("Time constant `Ta` has to be strictly positive"))
+    @symcheck T > 0 || throw(ArgumentError("Time constant `T` has to be strictly positive"))
+    @symcheck u_max ≥ u_min || throw(ArgumentError("u_min must be smaller than u_max"))
     @named err_input = RealInput() # control error
     @named ctr_output = RealOutput() # control signal
     @named gainPI = Gain(k)
@@ -367,8 +368,9 @@ where the transfer function for the derivative includes additional filtering, se
         (Ti ≥ 0 || throw(ArgumentError("Ti out of bounds, got $(Ti) but expected Ti ≥ 0")))
     !isequal(Td, false) &&
         (Td ≥ 0 || throw(ArgumentError("Td out of bounds, got $(Td) but expected Td ≥ 0")))
-    u_max ≥ u_min || throw(ArgumentError("u_min must be smaller than u_max"))
-    Nd > 0 || throw(ArgumentError("Nd out of bounds, got $(Nd) but expected Nd > 0"))
+    @symcheck u_max ≥ u_min || throw(ArgumentError("u_min must be smaller than u_max"))
+    @symcheck Nd > 0 ||
+              throw(ArgumentError("Nd out of bounds, got $(Nd) but expected Nd > 0"))
 
     @named reference = RealInput()
     @named measurement = RealInput()

--- a/src/Blocks/nonlinear.jl
+++ b/src/Blocks/nonlinear.jl
@@ -17,7 +17,7 @@ Limit the range of a signal.
   - `output`
 """
 @component function Limiter(; name, y_max, y_min = y_max > 0 ? -y_max : -Inf)
-    y_max ≥ y_min || throw(ArgumentError("`y_min` must be smaller than `y_max`"))
+    @symcheck y_max ≥ y_min || throw(ArgumentError("`y_min` must be smaller than `y_max`"))
     @named siso = SISO()
     @unpack u, y = siso
     pars = @parameters y_max=y_max [description = "Maximum allowed output of Limiter $name"] y_min=y_min [

--- a/src/Mechanical/Rotational/Rotational.jl
+++ b/src/Mechanical/Rotational/Rotational.jl
@@ -5,6 +5,7 @@ module Rotational
 
 using ModelingToolkit, Symbolics, IfElse
 using ...Blocks: RealInput, RealOutput
+using ..ModelingToolkitStandardLibrary: @symcheck
 
 @parameters t
 D = Differential(t)

--- a/src/Mechanical/Rotational/Rotational.jl
+++ b/src/Mechanical/Rotational/Rotational.jl
@@ -5,7 +5,7 @@ module Rotational
 
 using ModelingToolkit, Symbolics, IfElse
 using ...Blocks: RealInput, RealOutput
-import ..@symcheck
+import ...@symcheck
 
 @parameters t
 D = Differential(t)

--- a/src/Mechanical/Rotational/Rotational.jl
+++ b/src/Mechanical/Rotational/Rotational.jl
@@ -5,7 +5,7 @@ module Rotational
 
 using ModelingToolkit, Symbolics, IfElse
 using ...Blocks: RealInput, RealOutput
-using ..ModelingToolkitStandardLibrary: @symcheck
+import ..@symcheck
 
 @parameters t
 D = Differential(t)

--- a/src/Mechanical/Rotational/components.jl
+++ b/src/Mechanical/Rotational/components.jl
@@ -44,7 +44,7 @@ end
 @component function Inertia(; name, J, phi_start = 0.0, w_start = 0.0, a_start = 0.0)
     @named flange_a = Flange()
     @named flange_b = Flange()
-    J > 0 || throw(ArgumentError("Expected `J` to be positive"))
+    @symcheck J > 0 || throw(ArgumentError("Expected `J` to be positive"))
     @parameters J=J [description = "Moment of inertia of $name"]
     sts = @variables(phi(t)=phi_start, [description = "Absolute rotation angle of $name"],
                      w(t)=w_start, [description = "Absolute angular velocity of $name"],
@@ -81,7 +81,7 @@ Linear 1D rotational spring
 @component function Spring(; name, c, phi_rel0 = 0.0)
     @named partial_comp = PartialCompliant()
     @unpack phi_rel, tau = partial_comp
-    c > 0 || throw(ArgumentError("Expected `c` to be positive"))
+    @symcheck c > 0 || throw(ArgumentError("Expected `c` to be positive"))
     pars = @parameters(c=c, [description = "Spring constant of $name"],
                        phi_rel0=phi_rel0,
                        [description = "Unstretched spring angle of $name"],)
@@ -113,7 +113,7 @@ Linear 1D rotational damper
 @component function Damper(; name, d)
     @named partial_comp = PartialCompliantWithRelativeStates()
     @unpack w_rel, tau = partial_comp
-    d > 0 || throw(ArgumentError("Expected `d` to be positive"))
+    @symcheck d > 0 || throw(ArgumentError("Expected `d` to be positive"))
     pars = @parameters d=d [description = "Damping constant of $name"]
     eqs = [tau ~ d * w_rel]
     extend(ODESystem(eqs, t, [], pars; name = name), partial_comp)
@@ -145,7 +145,7 @@ This element characterizes any type of gear box which is fixed in the ground and
 @component function IdealGear(; name, ratio, use_support = false)
     @named partial_element = PartialElementaryTwoFlangesAndSupport2(use_support = use_support)
     @unpack phi_support, flange_a, flange_b = partial_element
-    ratio > 0 || throw(ArgumentError("Expected `ratio` to be positive"))
+    @symcheck ratio > 0 || throw(ArgumentError("Expected `ratio` to be positive"))
     @parameters ratio=ratio [description = "Transmission ratio of $name"]
     sts = @variables phi_a(t)=0.0 [
         description = "Relative angle between shaft a and the support of $name",

--- a/src/ModelingToolkitStandardLibrary.jl
+++ b/src/ModelingToolkitStandardLibrary.jl
@@ -1,5 +1,21 @@
 module ModelingToolkitStandardLibrary
 
+"""
+  @symcheck J > 0 || throw(ArgumentError("Expected `J` to be positive"))
+  
+Omits the check expression if the argument `J` is symbolic.
+"""
+macro symcheck(ex)
+    ex.args[1].head === :call ||
+        error("Expected an expresion on the form sym > val || error()")
+    sym = ex.args[1].args[2]
+    quote
+        _issymbolic($(esc(sym))) || ($(esc(ex)))
+    end
+end
+
+_issymbolic(x) = !(Symbolics.unwrap(x) isa Real)
+
 include("Blocks/Blocks.jl")
 include("Mechanical/Mechanical.jl")
 include("Thermal/Thermal.jl")

--- a/src/ModelingToolkitStandardLibrary.jl
+++ b/src/ModelingToolkitStandardLibrary.jl
@@ -16,7 +16,6 @@ macro symcheck(ex)
     end
 end
 
-
 include("Blocks/Blocks.jl")
 include("Mechanical/Mechanical.jl")
 include("Thermal/Thermal.jl")

--- a/src/ModelingToolkitStandardLibrary.jl
+++ b/src/ModelingToolkitStandardLibrary.jl
@@ -1,4 +1,5 @@
 module ModelingToolkitStandardLibrary
+import Symbolics: unwrap
 
 """
   @symcheck J > 0 || throw(ArgumentError("Expected `J` to be positive"))
@@ -10,11 +11,11 @@ macro symcheck(ex)
         error("Expected an expresion on the form sym > val || error()")
     sym = ex.args[1].args[2]
     quote
+        _issymbolic(x) = !(unwrap(x) isa Real)
         _issymbolic($(esc(sym))) || ($(esc(ex)))
     end
 end
 
-_issymbolic(x) = !(Symbolics.unwrap(x) isa Real)
 
 include("Blocks/Blocks.jl")
 include("Mechanical/Mechanical.jl")


### PR DESCRIPTION
and apply it to several argument checks. This macro skips the check in case the input argument is a symbolic variable, in which case a non-boolean would have been used in a boolean context.