### PR TITLE
allow output to be sym variable in linearize

### DIFF
--- a/test/Blocks/test_analysis_points.jl
+++ b/test/Blocks/test_analysis_points.jl
@@ -99,6 +99,10 @@ matrices, _ = linearize(sys, :plant_input, :plant_output)
 @test matrices.B[] * matrices.C[] == 1 # both positive
 @test matrices.D[] == 0
 
+# Test with output given by symbolic variable instead of analysis point
+matrices2, _ = linearize(sys, :plant_input, [P.output.u])
+@test matrices2 == matrices
+
 ## Test with subsystems
 
 @named P = FirstOrder(k = 1, T = 1)


### PR DESCRIPTION
The output signal does not have to be an analysis point like the input does. The difference lies in that to handle an input, an extra equation is added to the model, whereas to handle the output we simply create an observed function.