### PR TITLE
Add `th_ground` to list of systems

### DIFF
--- a/test/Thermal/thermal.jl
+++ b/test/Thermal/thermal.jl
@@ -182,7 +182,7 @@ end
            connect(mass.port, th_ground.port)]
     @named coll = ODESystem(eqs, t,
                             systems = [hf_sensor, flow_src, tem_src,
-                                collector, th_resistor, mass])
+                                collector, th_resistor, mass, th_ground])
     sys = structural_simplify(coll)
 
     u0 = [


### PR DESCRIPTION
This is necessary for DAECompiler, but seems to break MTK v8.57.0:

```
julia> sys = structural_simplify(coll)
ERROR: ExtraEquationsSystemException: The system is unbalanced. There are 27 highest order derivative variables and 28 equations.
More equations than variables, here are the potential extra equation(s):
 0 ~ th_ground₊T - th_ground₊port₊T(t)
 0 ~ th_ground₊port₊T(t) - mass₊port₊T(t)
Stacktrace:
 [1] error_reporting(state::TearingState{ODESystem}, bad_idxs::Vector{Int64}, n_highest_vars::Int64, iseqs::Bool, orig_inputs::Set{Any})
   @ ModelingToolkit.StructuralTransformations ~/.julia/dev/ModelingToolkit/src/structural_transformation/utils.jl:44
 [2] check_consistency(state::TearingState{ODESystem}, orig_inputs::Set{Any})
   @ ModelingToolkit.StructuralTransformations ~/.julia/dev/ModelingToolkit/src/structural_transformation/utils.jl:85
 [3] _structural_simplify!(state::TearingState{…}, io::Nothing; simplify::Bool, check_consistency::Bool, kwargs::Base.Pairs{…})
   @ ModelingToolkit.SystemStructures ~/.julia/dev/ModelingToolkit/src/systems/systemstructure.jl:607
 [4] kwcall(::NamedTuple, ::typeof(ModelingToolkit.SystemStructures._structural_simplify!), state::TearingState, io::Any)
   @ ModelingToolkit.SystemStructures ~/.julia/dev/ModelingToolkit/src/systems/systemstructure.jl:597 [inlined]
 [5] structural_simplify!(state::TearingState{…}, io::Nothing; simplify::Bool, check_consistency::Bool, kwargs::Base.Pairs{…})
   @ ModelingToolkit.SystemStructures ~/.julia/dev/ModelingToolkit/src/systems/systemstructure.jl:563
 [6] structural_simplify(sys::ODESystem, io::Nothing; simplify::Bool, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, @NamedTuple{}})
   @ ModelingToolkit ~/.julia/dev/ModelingToolkit/src/systems/systems.jl:39
 [7] structural_simplify(sys::ODESystem, io::Nothing)
   @ ModelingToolkit ~/.julia/dev/ModelingToolkit/src/systems/systems.jl:19 [inlined]
 [8] top-level scope
   @ REPL[17]:1
Some type information was truncated. Use `show(err)` to see complete types.
```