### PR TITLE
fix: Ground with new model syntax

### DIFF
--- a/src/Electrical/Analog/ideal_components.jl
+++ b/src/Electrical/Analog/ideal_components.jl
@@ -8,10 +8,9 @@ node.
 
   - `g`
 """
-@component function Ground(; name)
-    @named g = Pin()
-    eqs = [g.v ~ 0]
-    ODESystem(eqs, t, [], []; systems = [g], name = name)
+@model Ground begin # (; name)
+    @components begin g = Pin() end
+    @equations begin g.v ~ 0 end
 end
 
 """


### PR DESCRIPTION
Description:
Convert all components needed for [DC Motor with PI-controller](https://docs.sciml.ai/ModelingToolkitStandardLibrary/stable/tutorials/dc_motor_pi/#DC-Motor-with-PI-controller) to the new `@model` syntax.

Questions:
- When should `@extend` be used in favor of `@components`?