### PR TITLE
Don't export IdealGear from TranslationalPosition and TranslationalModelica

### DIFF
--- a/src/Mechanical/TranslationalModelica/TranslationalModelica.jl
+++ b/src/Mechanical/TranslationalModelica/TranslationalModelica.jl
@@ -12,7 +12,7 @@ D = Differential(t)
 export Flange
 include("utils.jl")
 
-export Fixed, Mass, Spring, Damper, IdealGear
+export Fixed, Mass, Spring, Damper
 include("components.jl")
 
 export Force

--- a/src/Mechanical/TranslationalPosition/TranslationalPosition.jl
+++ b/src/Mechanical/TranslationalPosition/TranslationalPosition.jl
@@ -12,7 +12,7 @@ D = Differential(t)
 export Flange
 include("utils.jl")
 
-export Fixed, Mass, Spring, Damper, IdealGear
+export Fixed, Mass, Spring, Damper
 include("components.jl")
 
 export Force


### PR DESCRIPTION
- It isn't implemented in those libs

I don't see any implementation of IdealGear in these libs. @baggepinnen can we just drop them or do we want to reexport Rotational.IdealGear?