### PR TITLE
docs: fix `Blocks.Sum` docstring

### DIFF
--- a/src/Blocks/math.jl
+++ b/src/Blocks/math.jl
@@ -57,10 +57,10 @@ end
 MatrixGain.f(K; name) = MatrixGain.f(; name, K)
 
 """
-    Sum(; input.nin::Int, name)
+    Sum(; input__nin::Int, name)
 
 Output the sum of the elements of the input port vector.
-Input port dimension can be set with `input.nin`
+Input port dimension can be set with `input__nin`
 
 # Connectors:
 


### PR DESCRIPTION
MWE:
```julia
julia> Sum(;name=:a, input.nin=2)
ERROR: syntax: invalid keyword argument name "input.nin" around REPL[8]:1
Stacktrace:
 [1] top-level scope
   @ REPL[8]:

julia> @macroexpand @mtkmodel Sum begin
           @components begin
               input = RealInput(; nin)
               output = RealOutput()
           end
           @equations begin
               output.u ~ sum(input.u)
           end
       end
:(Sum = (ModelingToolkit.Model)(((; name, input__nin = nothing)->begin
                  #= /Users/aayush/.julia/packages/ModelingToolkit/xLMQM/src/systems/model_parsing.jl:242 =#
                  begin
                      begin
                          input = RealInput(name = :input; nin = input__nin)
                          output = RealOutput(name = :output)
                      end
                      (ODESystem)((Equation)[output.u ~ sum(input.u)], t, [], []; systems = [input, output], name, gui_metadata = nothing)
                  end
              end), Dict{Symbol, Any}(:components => [[:input, :RealInput], [:output, :RealOutput]], :kwargs => Dict{Symbol, Any}(), :independent_variable => t, :equations => ["output.u ~ sum(input.u)"]), false))

julia> Sum(;name=:a, input__nin=2)
Model a with 1 equations
...
```