### PR TITLE
Source bugs fixed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,14 @@ authors = ["Chris Rackauckas and Julia Computing"]
 version = "2.1.0"
 
 [deps]
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
+DiffEqBase = "6"
 IfElse = "0.1"
 ModelingToolkit = "8.50"
 Symbolics = "4.9, 5"

--- a/src/Blocks/sources.jl
+++ b/src/Blocks/sources.jl
@@ -626,9 +626,9 @@ function set_sampled_data!(memory::Parameter{T}, t, x, Δt::Parameter{T}) where 
     n = length(memory.data)
     i = round(Int, t / Δt) + 1 #expensive
     if i == n + 1
-        push!(memory.data, x)
+        push!(memory.data, ModelingToolkit.ForwardDiff.value(x))
     elseif i <= n
-        @inbounds memory.data[i] = x
+        @inbounds memory.data[i] = ModelingToolkit.ForwardDiff.value(x)
     else
         error("Memory buffer skipped a step: n=$n, i=$i")
     end

--- a/src/Blocks/sources.jl
+++ b/src/Blocks/sources.jl
@@ -1,3 +1,5 @@
+using DiffEqBase
+
 # Define and register smooth functions
 # These are "smooth" aka differentiable and avoid Gibbs effect
 # These follow: `offset` + `smooth_wave` * `smooth_step` with zero output for `t < start_time`
@@ -626,9 +628,9 @@ function set_sampled_data!(memory::Parameter{T}, t, x, Δt::Parameter{T}) where 
     n = length(memory.data)
     i = round(Int, t / Δt) + 1 #expensive
     if i == n + 1
-        push!(memory.data, ModelingToolkit.ForwardDiff.value(x))
+        push!(memory.data, DiffEqBase.value(x))
     elseif i <= n
-        @inbounds memory.data[i] = ModelingToolkit.ForwardDiff.value(x)
+        @inbounds memory.data[i] = DiffEqBase.value(x)
     else
         error("Memory buffer skipped a step: n=$n, i=$i")
     end

--- a/src/Mechanical/Translational/sources.jl
+++ b/src/Mechanical/Translational/sources.jl
@@ -20,35 +20,46 @@ Linear 1D force input source
 end
 
 """
-    Position(; s.u_start = 0.0, name)
+    Position(solves_force = true; name)
 
-Linear 1D position input source
+Linear 1D position input source.  Set `solves_force=false` to force input force to 0 (i.e. only the position is given, the respective force needed is already provided elsewhere in the model).  
 
 # Connectors:
 
   - `flange`: 1-dim. translational flange
-  - `s`: real input. `s.u_start` accepts an initial value, which It accepts an initial value, which defaults to 0.0.
+  - `s`: real input
 """
-@component function Position(; solves_force = true, s__u_start = 0, name)
+@component function Position(solves_force = true; name)
+    vars = []
+
     systems = @named begin
-        flange = MechanicalPort()
+        flange = MechanicalPort(; v = 0)
         s = RealInput()
     end
 
-    vars = @variables x(t)
-
-    eqs = [D(x) ~ flange.v
-        s.u ~ x]
+    eqs = [
+        D(s.u) ~ flange.v,
+    ]
 
     !solves_force && push!(eqs, 0 ~ flange.f)
 
     ODESystem(eqs, t, vars, [];
-        name, systems, defaults = [flange.v => 0, s.u => s__u_start])
+        name, systems)
 end
 
-@component function Velocity(; solves_force = true, name)
+"""
+    Velocity(solves_force = true; name)
+
+Linear 1D position input source.  Set `solves_force=false` to force input force to 0 (i.e. only the velocity is given, the respective force needed is already provided elsewhere in the model).  
+
+# Connectors:
+
+  - `flange`: 1-dim. translational flange
+  - `v`: real input
+"""
+@component function Velocity(solves_force = true; name)
     systems = @named begin
-        flange = MechanicalPort()
+        flange = MechanicalPort(; v = 0)
         v = RealInput()
     end
 
@@ -58,13 +69,23 @@ end
 
     !solves_force && push!(eqs, 0 ~ flange.f)
 
-    ODESystem(eqs, t, [], []; name, systems, defaults = [flange.v => 0])
+    ODESystem(eqs, t, [], []; name, systems)
 end
 
-@component function Acceleration(solves_force = true; s__u_start = 0, name)
+"""
+Acceleration(solves_force = true; name)
+
+Linear 1D position input source.  Set `solves_force=false` to force input force to 0 (i.e. only the acceleration is given, the respective force needed is already provided elsewhere in the model).  
+
+# Connectors:
+
+  - `flange`: 1-dim. translational flange
+  - `a`: real input
+"""
+@component function Acceleration(solves_force = true; name)
     systems = @named begin
-        flange = MechanicalPort()
-        a = RealInput(; u_start = s__u_start)
+        flange = MechanicalPort(; v = 0)
+        a = RealInput()
     end
 
     vars = @variables v(t) = 0
@@ -74,5 +95,5 @@ end
 
     !solves_force && push!(eqs, 0 ~ flange.f)
 
-    ODESystem(eqs, t, vars, []; name, systems, defaults = [flange.v => 0])
+    ODESystem(eqs, t, vars, []; name, systems)
 end

--- a/test/Hydraulic/isothermal_compressible.jl
+++ b/test/Hydraulic/isothermal_compressible.jl
@@ -244,7 +244,7 @@ end
             body = T.Mass(; m = 1500)
             pipe = IC.Tube(5; p_int = p_2, area = A_2, length = 2.0)
             snk = IC.FixedPressure(; p = p_r)
-            pos = T.Position(; s.u_start = 0)
+            pos = T.Position()
 
             m1 = IC.FlowDivider(; p_int = p_2, n = 3)
             m2 = IC.FlowDivider(; p_int = p_2, n = 3)

--- a/test/Mechanical/translational.jl
+++ b/test/Mechanical/translational.jl
@@ -119,7 +119,7 @@ end
 @testset "sources & sensors" begin
     function System(; name)
         systems = @named begin
-            pos = TV.Position(; s.u_start = 0)
+            pos = TV.Position()
             pos_sensor = TV.PositionSensor(; s = 1)
             force = TV.Force()
             force_sensor = TV.ForceSensor()


### PR DESCRIPTION
Fixed a couple bugs/breaking changes from v2
- `Mechanical.Translational` `Position`, `Velocity`, and `Acceleration` had all changed the initial position keyword (from `s_0` to `s__u_start`).  Turns out the initial position setting is never actually needed because the `RealInput` connector should always be driven by an absolute value, therefore this keyword is removed.
- Calculating ForwardDiff derivatives with the `Blocks.SampledData` component was not working.  Included `ForwardDiff.value()` to handle `Dual` type calls