### PR TITLE
docs: use `idxs` instead of `vars` for plotting in tutorials

### DIFF
--- a/docs/src/tutorials/custom_component.md
+++ b/docs/src/tutorials/custom_component.md
@@ -131,7 +131,7 @@ Plots.plot(sol[C1.v], sol[C2.v], title = "Chaotic Attractor", label = "",
 Plots.savefig("chua_phase_plane.png")
 nothing # hide
 
-Plots.plot(sol; vars = [C1.v, C2.v, L.i],
+Plots.plot(sol; idxs = [C1.v, C2.v, L.i],
     labels = ["C1 Voltage in V" "C1 Voltage in V" "Inductor Current in A"])
 Plots.savefig("chua.png")
 nothing # hide

--- a/docs/src/tutorials/rc_circuit.md
+++ b/docs/src/tutorials/rc_circuit.md
@@ -31,7 +31,7 @@ rc_eqs = [connect(constant.output, source.V)
 sys = structural_simplify(rc_model)
 prob = ODAEProblem(sys, Pair[], (0, 10.0))
 sol = solve(prob, Tsit5())
-plot(sol, vars = [capacitor.v, resistor.i],
+plot(sol, idxs = [capacitor.v, resistor.i],
     title = "RC Circuit Demonstration",
     labels = ["Capacitor Voltage" "Resistor Current"])
 savefig("plot.png");

--- a/docs/src/tutorials/thermal_model.md
+++ b/docs/src/tutorials/thermal_model.md
@@ -35,7 +35,7 @@ sol = solve(prob, Tsit5())
 T_final_K = sol[(mass1.T * C1 + mass2.T * C2) / (C1 + C2)]
 
 plot(title = "Thermal Conduction Demonstration")
-plot!(sol, vars = [mass1.T, mass2.T], labels = ["Mass 1 Temperature" "Mass 2 Temperature"])
+plot!(sol, idxs = [mass1.T, mass2.T], labels = ["Mass 1 Temperature" "Mass 2 Temperature"])
 plot!(sol.t, T_final_K, label = "Steady-State Temperature")
 savefig("thermal_plot.png");
 nothing; # hide


### PR DESCRIPTION
This is to avoid this warning popping up in the docs:

```julia
┌ Warning: To maintain consistency with solution indexing, keyword argument vars will be removed in a future version. Please use keyword argument idxs instead.
│   caller = ip:0x0
└ @ Core :-1
```