### PR TITLE
Use lowest order differentiated variables to improve state selection

### DIFF
--- a/src/Blocks/math.jl
+++ b/src/Blocks/math.jl
@@ -50,7 +50,7 @@ Output the product of a gain matrix with the input signal vector.
         output = RealOutput(; nout = size(K, 1))
     end
     @equations begin
-        [(@info i, j; output.u[i] ~ sum(getdefault(K)[i, j] * input.u[j])) for j in 1:nin
+        [output.u[i] ~ sum(getdefault(K)[i, j] * input.u[j] for j in 1:nin)
          for i in 1:nout]...
     end
 end

--- a/src/Mechanical/MultiBody2D/MultiBody2D.jl
+++ b/src/Mechanical/MultiBody2D/MultiBody2D.jl
@@ -1,7 +1,7 @@
 module MultiBody2D
 
 using ModelingToolkit, Symbolics, IfElse
-using ..Translational
+using ..TranslationalPosition
 
 @parameters t
 D = Differential(t)

--- a/src/Mechanical/MultiBody2D/components.jl
+++ b/src/Mechanical/MultiBody2D/components.jl
@@ -41,11 +41,11 @@
     end
 
     @components begin
-        TX1 = MechanicalPort()
-        TY1 = MechanicalPort()
+        TX1 = Flange()
+        TY1 = Flange()
 
-        TX2 = MechanicalPort()
-        TY2 = MechanicalPort()
+        TX2 = Flange()
+        TY2 = Flange()
     end
 
     @equations begin
@@ -76,12 +76,12 @@
         x_cm ~ l * cos(A) / 2 + x1
         y_cm ~ l * sin(A) / 2 + y1
         TX1.f ~ fx1
-        TX1.v ~ dx1
+        TX1.s ~ x1
         TY1.f ~ fy1
-        TY1.v ~ dy1
+        TY1.s ~ y1
         TX2.f ~ fx2
-        TX2.v ~ dx2
+        TX2.s ~ x2
         TY2.f ~ fy2
-        TY2.v ~ dy2
+        TY2.s ~ y2
     end
 end

--- a/src/Mechanical/TranslationalPosition/components.jl
+++ b/src/Mechanical/TranslationalPosition/components.jl
@@ -13,7 +13,7 @@ Flange fixed in housing at a given position.
 """
 @mtkmodel Fixed begin
     @parameters begin
-        s_0
+        s_0 = 0
     end
     @components begin
         flange = Flange(; s = s_0)

--- a/src/Mechanical/TranslationalPosition/sources.jl
+++ b/src/Mechanical/TranslationalPosition/sources.jl
@@ -5,11 +5,11 @@ Input signal acting as external force on a flange
 """
 @mtkmodel Force begin
     @parameters begin
-        use_support
+        s = 0
     end
-    @extend (flange,) = partial_element = PartialElementaryOneFlangeAndSupport2(use_support = use_support)
     @components begin
-        f = RealInput() # Accelerating force acting at flange (= -flange.tau)
+        flange = Flange(; s = s)
+        f = RealInput()
     end
     @equations begin
         flange.f ~ -f.u

--- a/src/Mechanical/TranslationalPosition/sources.jl
+++ b/src/Mechanical/TranslationalPosition/sources.jl
@@ -5,8 +5,12 @@ Input signal acting as external force on a flange
 """
 @mtkmodel Force begin
     @parameters begin
+        use_support = false
         s = 0
     end
+    @extend (flange,) = partial_element = PartialElementaryOneFlangeAndSupport2(;
+        use_support = use_support isa Bool ? use_support :
+                      ModelingToolkit.getdefault(use_support))
     @components begin
         flange = Flange(; s = s)
         f = RealInput()

--- a/test/Mechanical/multibody.jl
+++ b/test/Mechanical/multibody.jl
@@ -1,6 +1,6 @@
 using ModelingToolkit
 using ModelingToolkitStandardLibrary.Mechanical.MultiBody2D
-using ModelingToolkitStandardLibrary.Mechanical.Translational
+using ModelingToolkitStandardLibrary.Mechanical.TranslationalPosition
 using DifferentialEquations
 # using Setfield
 using Test

--- a/test/Mechanical/multibody.jl
+++ b/test/Mechanical/multibody.jl
@@ -23,6 +23,7 @@ eqs = [connect(link1.TX1, cart.flange) #, force.flange)
 @named model = ODESystem(eqs, t, [], []; systems = [link1, link2, cart, fixed])
 
 sys = structural_simplify(model)
+@test length(states(sys)) == 6
 
 # The below code does work...
 #=


### PR DESCRIPTION
Note that we can infer `D(x) = D(y)` from `x = y`, but we cannot infer `x = y` from `D(x) = D(y)`, so using the lowest variable in the connector provides more information to the compiler.