### PR TITLE
Fix frule

### DIFF
--- a/src/Hydraulic/IsothermalCompressible/utils.jl
+++ b/src/Hydraulic/IsothermalCompressible/utils.jl
@@ -119,7 +119,7 @@ end
 Symbolics.derivative(::typeof(friction_factor), args, ::Val{1}) = 0
 Symbolics.derivative(::typeof(friction_factor), args, ::Val{4}) = 0
 function ChainRulesCore.frule(_, ::typeof(friction_factor), args...)
-    (friction_factor(args...), ChainRulesCore.ZeroTangent)
+    (friction_factor(args...), ChainRulesCore.ZeroTangent())
 end
 
 function transition(x1, x2, y1, y2, x)


### PR DESCRIPTION
Bug was introduced in https://github.com/SciML/ModelingToolkitStandardLibrary.jl/pull/204/
seems like it was just a typo.

This was breaking ability to use Diffractor on things using MSL
