### PR TITLE
initialize all relevant variables for SISO

### DIFF
--- a/src/Blocks/nonlinear.jl
+++ b/src/Blocks/nonlinear.jl
@@ -18,7 +18,8 @@ Limit the range of a signal.
 """
 @component function Limiter(; name, y_max, y_min = y_max > 0 ? -y_max : -Inf)
     @symcheck y_max ≥ y_min || throw(ArgumentError("`y_min` must be smaller than `y_max`"))
-    @named siso = SISO()
+    m = (y_max + y_min) / 2
+    @named siso = SISO(u_start = m, y_start = m) # Default signals to center of saturation to minimize risk of saturation while linearizing etc.
     @unpack u, y = siso
     pars = @parameters y_max=y_max [description = "Maximum allowed output of Limiter $name"] y_min=y_min [
         description = "Minimum allowed output of Limiter $name",

--- a/src/Blocks/utils.jl
+++ b/src/Blocks/utils.jl
@@ -74,8 +74,8 @@ Single input single output (SISO) continuous system block.
         y(t) = y_start, [description = "Output of SISO system"]
     end
     @components begin
-        input = RealInput(u_start = 0.0)
-        output = RealOutput(u_start = 0.0)
+        input = RealInput(u_start = u_start)
+        output = RealOutput(u_start = y_start)
     end
     @equations begin
         u ~ input.u


### PR DESCRIPTION
This PR makes sure to pass initial values to also connector variables (they are supposed to be equal), and by default initializes the limiter to the center of the limit band. Having the limiter in the non-saturated region by default is important for linearization, you get the zero system otherwise.