### PR TITLE
More CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,32 +10,34 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
+  schedule:
+    - cron: '41 10 * * 0'
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         group:
-          - All
+          - Core
         version:
           - '1'
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-      - uses: actions/cache@v3
-        env:
-          cache-name: cache-artifacts
+      - uses: julia-actions/cache@v1
         with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          depwarn: error
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -6,7 +6,8 @@ on:
       - main
     tags: '*'
   pull_request:
-
+  schedule:
+    - cron: '41 10 * * 0'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -10,20 +10,32 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
+  schedule:
+    - cron: '41 10 * * 0'
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        version: ['1']
+        group:
+          - Core
+        version:
+          - '1'
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
       - uses: cjdoris/julia-downgrade-compat-action@v1
-#        if: ${{ matrix.version == '1.6' }}
         with:
           skip: Pkg,TOML
+      - uses: julia-actions/cache@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -1,29 +1,47 @@
+
 name: IntegrationTest
 on:
-  push:
-    branches: [master]
-    tags: [v*]
   pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+    paths-ignore:
+      - 'docs/**'
+  schedule:
+    - cron: '41 10 * * 0'
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.version }}
     runs-on: ${{ matrix.os }}
     env:
       GROUP: ${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1]
-        os: [ubuntu-latest]
         package:
-          - {user: SciML, repo: ModelingToolkit.jl}
+          - {user: SciML, repo: ModelingToolkit.jl, group: All}
+        version:
+          - '1'
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: ${{ matrix.julia-version }}
+          version: ${{ matrix.version }}
           arch: x64
+      - uses: julia-actions/cache@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: julia-actions/julia-buildpkg@latest
       - name: Clone Downstream
         uses: actions/checkout@v4
@@ -31,7 +49,7 @@ jobs:
           repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
           path: downstream
       - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
+        shell: julia --color=yes --depwarn=error --project=downstream {0}
         run: |
           using Pkg
           try

--- a/test/Electrical/analog.jl
+++ b/test/Electrical/analog.jl
@@ -276,7 +276,7 @@ _damped_sine_wave(x, f, A, st, ϕ, d) = exp((st - x) * d) * A * sin(2 * π * f *
 
     for i in 1:lastindex(sources)
         source = sources[i]
-        @info "Testing Voltage with $(source.name) source"
+        @info "Testing Voltage with $(source.get_name) source"
         eqs = [connect(source.output, voltage.V)
             connect(voltage.p, voltage_sensor.p, res.p)
             connect(res.n, cap.p)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,70 +1,32 @@
 using SafeTestsets
 
-@safetestset "Quality Assurance" begin
-    include("qa.jl")
-end
+@time @safetestset "Quality Assurance" include("qa.jl")
 
 # Blocks
-@safetestset "Blocks: math" begin
-    include("Blocks/math.jl")
-end
-@safetestset "Blocks: nonlinear" begin
-    include("Blocks/nonlinear.jl")
-end
-@safetestset "Blocks: continuous" begin
-    include("Blocks/continuous.jl")
-end
-@safetestset "Blocks: sources" begin
-    include("Blocks/sources.jl")
-end
-@safetestset "Blocks: analysis points" begin
-    include("Blocks/test_analysis_points.jl")
-end
+@time @safetestset "Blocks: math" include("Blocks/math.jl")
+@time @safetestset "Blocks: nonlinear" include("Blocks/nonlinear.jl")
+@time @safetestset "Blocks: continuous" include("Blocks/continuous.jl")
+@time @safetestset "Blocks: sources" include("Blocks/sources.jl")
+@time @safetestset "Blocks: analysis points" include("Blocks/test_analysis_points.jl")
 
 # Electrical
-@safetestset "Analog Circuits" begin
-    include("Electrical/analog.jl")
-end
-
-@safetestset "Chua Circuit Demo" begin
-    include("chua_circuit.jl")
-end
-
-@safetestset "Digital Circuits" begin
-    include("Electrical/digital.jl")
-end
-@safetestset "Chua Circuit Demo" begin
-    include("chua_circuit.jl")
-end
+@time @safetestset "Analog Circuits" include("Electrical/analog.jl")
+@time @safetestset "Chua Circuit Demo" include("chua_circuit.jl")
+@time @safetestset "Digital Circuits" include("Electrical/digital.jl")
+@time @safetestset "Chua Circuit Demo" include("chua_circuit.jl")
 
 # Thermal
-@safetestset "Thermal Circuits" begin
-    include("Thermal/thermal.jl")
-end
-@safetestset "Thermal Demo" begin
-    include("Thermal/demo.jl")
-end
+@time @safetestset "Thermal Circuits" include("Thermal/thermal.jl")
+@time @safetestset "Thermal Demo" include("Thermal/demo.jl")
 
 # Magnetic
-@safetestset "Magnetic" begin
-    include("Magnetic/magnetic.jl")
-end
+@time @safetestset "Magnetic" include("Magnetic/magnetic.jl")
 
 # Mechanical
-@safetestset "Mechanical Rotation" begin
-    include("Mechanical/rotational.jl")
-end
-@safetestset "Mechanical Translation" begin
-    include("Mechanical/translational.jl")
-end
-@safetestset "Mechanical Translation" begin
-    include("Mechanical/translational_modelica.jl")
-end
-@safetestset "Multi-Domain" begin
-    include("multi_domain.jl")
-end
+@time @safetestset "Mechanical Rotation" include("Mechanical/rotational.jl")
+@time @safetestset "Mechanical Translation" include("Mechanical/translational.jl")
+@time @safetestset "Mechanical Translation" include("Mechanical/translational_modelica.jl")
+@time @safetestset "Multi-Domain" include("multi_domain.jl")
 
 # Hydraulic
-@safetestset "Hydraulic IsothermalCompressible" begin
-    include("Hydraulic/isothermal_compressible.jl")
-end
+@time @safetestset "Hydraulic IsothermalCompressible" include("Hydraulic/isothermal_compressible.jl")


### PR DESCRIPTION
- What is the proper deprecation for sys.name? The suggested get_name(sys) does not seem to work.
- Downstream had no group, so I just picked the broadest one.