### PR TITLE
typo: misnamed C2.v in Chua's circuit tutorial

### DIFF
--- a/docs/src/tutorials/custom_component.md
+++ b/docs/src/tutorials/custom_component.md
@@ -132,7 +132,7 @@ Plots.savefig("chua_phase_plane.png")
 nothing # hide
 
 Plots.plot(sol; idxs = [C1.v, C2.v, L.i],
-    labels = ["C1 Voltage in V" "C1 Voltage in V" "Inductor Current in A"])
+    labels = ["C1 Voltage in V" "C2 Voltage in V" "Inductor Current in A"])
 Plots.savefig("chua.png")
 nothing # hide
 ```


### PR DESCRIPTION
This corrects the misnaming of the second variable in:

https://github.com/SciML/ModelingToolkitStandardLibrary.jl/blob/a8fc0ad98c84c363e17d56d4925957c217552057/docs/src/tutorials/custom_component.md?plain=1#L134-L135
