### PR TITLE
Tiny blocks documentation updates

### DIFF
--- a/src/Blocks/continuous.jl
+++ b/src/Blocks/continuous.jl
@@ -76,7 +76,7 @@ end
 """
     FirstOrder(; name, k = 1.0, T, x = 0.0, lowpass = true)
 
-A first-order filter with a single real pole in `s = -T` and gain `k`. If `lowpass=true` (default), the transfer function
+A first-order filter with a single real pole at `s = -1/T` and gain `k`. If `lowpass=true` (default), the transfer function
 is given by ``Y(s)/U(s) = ``
 
 

--- a/src/Blocks/sources.jl
+++ b/src/Blocks/sources.jl
@@ -157,7 +157,7 @@ end
     Cosine(; name, frequency, amplitude = 1, phase = 0, offset = 0, start_time = 0,
     smooth = false)
 
-Cosine signal.
+Generate cosine signal.
 
 # Parameters:
 - `frequency`: [Hz] Frequency of sine wave
@@ -171,7 +171,6 @@ Cosine signal.
 # Connectors:
 - `output`
 """
-
 @component function Cosine(; name,
         frequency,
         amplitude = 1,

--- a/src/Blocks/sources.jl
+++ b/src/Blocks/sources.jl
@@ -160,9 +160,9 @@ end
 Generate cosine signal.
 
 # Parameters:
-- `frequency`: [Hz] Frequency of sine wave
-- `amplitude`: Amplitude of sine wave
-- `phase`: [rad] Phase of sine wave
+- `frequency`: [Hz] Frequency of cosine wave
+- `amplitude`: Amplitude of cosine wave
+- `phase`: [rad] Phase of cosine wave
 - `offset`: Offset of output signal
 - `start_time`: [s] Output `y = offset` for `t < start_time`
 - `smooth`:  If `true`, returns a smooth wave. Defaults to `false`

--- a/src/Blocks/utils.jl
+++ b/src/Blocks/utils.jl
@@ -47,7 +47,7 @@ end
 Connector with one output signal of type Real.
 
 # Parameters:
-- `nout=1`: Number of inputs
+- `nout=1`: Number of outputs
 - `u_start=0`: Initial value for `u`
 
 # States:
@@ -61,8 +61,8 @@ Single input single output (SISO) continuous system block.
 
 # Parameters:
 
-  - `u`: Initial value for the input
-  - `y`: Initial value for the output
+  - `u_start`: Initial value for the input
+  - `y_start`: Initial value for the output
 """
 @mtkmodel SISO begin
     @parameters begin


### PR DESCRIPTION
* Small fixes
* In https://docs.sciml.ai/ModelingToolkitStandardLibrary/dev/API/blocks/#Source-Blocks, because of an empty line between doc string and the code block, I see missing doctstring for `Cosine`

![image](https://github.com/SciML/ModelingToolkitStandardLibrary.jl/assets/7318249/db35d102-236d-452e-99ef-54d79890f0d5)

