### PR TITLE
docs: cleaner and more concise transfer function of Derivative()

### DIFF
--- a/src/Blocks/continuous.jl
+++ b/src/Blocks/continuous.jl
@@ -35,24 +35,23 @@ end
     Derivative(; name, k = 1, T, x = 0.0)
 
 Outputs an approximate derivative of the input. The transfer function of this block is
-Initial value of the state ``x`` can be set with `x`
 
 ```
-k       k
-─ - ──────────
-T    2 ⎛    1⎞
-    T ⋅⎜s + ─⎟
-       ⎝    T⎠
+k      k        ks  
+─ - ─────── = ────── 
+T   sT² + T   sT + 1
 ```
 
 and a state-space realization is given by `ss(-1/T, 1/T, -k/T, k/T)`
 where `T` is the time constant of the filter.
 A smaller `T` leads to a more ideal approximation of the derivative.
 
+Initial value of the state ``x`` can be set with `x`.
+
 # Parameters:
 
   - `k`: Gain
-  - `T`: [s] Time constants (T>0 required; T=0 is ideal derivative block)
+  - `T`: [s] Time constant (T>0 required; T=0 is ideal derivative block)
 
 # Unknowns:
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

* Description of parameter `x` was inserted in https://github.com/SciML/ModelingToolkitStandardLibrary.jl/pull/191 but in wrong position, move it down
* Clean up transfer function of `Derivative`.  LHS is obtained from the implementation, the added RHS is simplified and the T->0 behavior is more obvious
