### PR TITLE
refactor(Blocks): add `RealInputArray` and `RealOutputArray`

### DIFF
--- a/src/Blocks/Blocks.jl
+++ b/src/Blocks/Blocks.jl
@@ -7,7 +7,7 @@ import IfElse: ifelse
 import ..@symcheck
 using ModelingToolkit: getdefault, t_nounits as t, D_nounits as D
 
-export RealInput, RealOutput, SISO
+export RealInput, RealInputArray, RealOutput, RealOutputArray, SISO
 include("utils.jl")
 
 export Gain, Sum, MatrixGain, Feedback, Add, Add3, Product, Division

--- a/src/Blocks/utils.jl
+++ b/src/Blocks/utils.jl
@@ -1,5 +1,6 @@
-@connector function RealInput(; name, nin = 1, u_start = nin > 1 ? zeros(nin) : 0.0)
-    if nin == 1
+@connector function RealInput(;
+        name, nin = 1, isarray = false, u_start = isarray ? zeros(nin) : 0.0)
+    if nin == 1 && !isarray
         @variables u(t)=u_start [
             input = true,
             description = "Inner variable in RealInput $name"
@@ -21,13 +22,15 @@ Connector with one input signal of type Real.
 # Parameters:
 - `nin=1`: Number of inputs
 - `u_start=0`: Initial value for `u`
+- `isarray=false`: This is only applicable for `nin=1`. Boolean flag to use a scalar or a one element symbolic vector
 
 # States:
 - `u`: Value of the connector; if nin=1 this is a scalar
 """ RealInput
 
-@connector function RealOutput(; name, nout = 1, u_start = nout > 1 ? zeros(nout) : 0.0)
-    if nout == 1
+@connector function RealOutput(;
+        name, nout = 1, isarray = false, u_start = isarray ? zeros(nout) : 0.0)
+    if nout == 1 && !isarray
         @variables u(t)=u_start [
             output = true,
             description = "Inner variable in RealOutput $name"
@@ -49,6 +52,7 @@ Connector with one output signal of type Real.
 # Parameters:
 - `nout=1`: Number of outputs
 - `u_start=0`: Initial value for `u`
+- `isarray=false`: This is only applicable for `nout=1`. Boolean flag to use a scalar or a one element symbolic vector
 
 # States:
 - `u`: Value of the connector; if nout=1 this is a scalar

--- a/src/Blocks/utils.jl
+++ b/src/Blocks/utils.jl
@@ -1,6 +1,6 @@
-@connector function RealInput(;
-        name, nin = 1, isarray = false, u_start = isarray ? zeros(nin) : 0.0)
-    if nin == 1 && !isarray
+@connector function RealInput(; name, nin = 1, u_start = nin > 1 ? zeros(nin) : 0.0)
+    nin > 1 && @warn "For inputs greater than one, use `RealInputArray`."
+    if nin == 1
         @variables u(t)=u_start [
             input = true,
             description = "Inner variable in RealInput $name"
@@ -15,22 +15,41 @@
     ODESystem(Equation[], t, [u...], []; name = name)
 end
 @doc """
-    RealInput(;name, nin, u_start)
+    RealInput(;name, u_start)
 
 Connector with one input signal of type Real.
 
 # Parameters:
-- `nin=1`: Number of inputs
-- `u_start=0`: Initial value for `u`
-- `isarray=false`: This is only applicable for `nin=1`. Boolean flag to use a scalar or a one element symbolic vector
+- `u_start=0`: Initial value for `u`.
 
 # States:
-- `u`: Value of the connector; if nin=1 this is a scalar
+- `u`: Value of the connector which is a scalar.
 """ RealInput
 
-@connector function RealOutput(;
-        name, nout = 1, isarray = false, u_start = isarray ? zeros(nout) : 0.0)
-    if nout == 1 && !isarray
+@connector function RealInputArray(; name, nin = 2, u_start = zeros(nin))
+    @variables u(t)[1:nin]=u_start [
+        input = true,
+        description = "Inner variable in RealInputArray $name"
+    ]
+    u = collect(u)
+    ODESystem(Equation[], t, [u...], []; name = name)
+end
+@doc """
+    RealInputArray(;name, nin, u_start)
+
+Connector with an array of input signals of type Real.
+
+# Parameters:
+- `nin=2`: Number of inputs.
+- `u_start=zeros(nin)`: Initial value for `u`.
+
+# States:
+- `u`: Value of the connector which is an array.
+""" RealInputArray
+
+@connector function RealOutput(; name, nout = 1, u_start = nout > 1 ? zeros(nout) : 0.0)
+    nout > 1 && @warn "For outputs greater than one, use `RealOutputArray`."
+    if nout == 1
         @variables u(t)=u_start [
             output = true,
             description = "Inner variable in RealOutput $name"
@@ -45,18 +64,37 @@ Connector with one input signal of type Real.
     ODESystem(Equation[], t, [u...], []; name = name)
 end
 @doc """
-    RealOutput(;name, nout, u_start)
+    RealOutput(;name, u_start)
 
 Connector with one output signal of type Real.
 
 # Parameters:
-- `nout=1`: Number of outputs
-- `u_start=0`: Initial value for `u`
-- `isarray=false`: This is only applicable for `nout=1`. Boolean flag to use a scalar or a one element symbolic vector
+- `u_start=0`: Initial value for `u`.
 
 # States:
-- `u`: Value of the connector; if nout=1 this is a scalar
+- `u`: Value of the connector which is a scalar.
 """ RealOutput
+
+@connector function RealOutputArray(; name, nout = 2, u_start = zeros(nout))
+    @variables u(t)[1:nout]=u_start [
+        output = true,
+        description = "Inner variable in RealOutput $name"
+    ]
+    u = collect(u)
+    ODESystem(Equation[], t, [u...], []; name = name)
+end
+@doc """
+    RealOutputArray(;name, nout, u_start)
+
+Connector with an array of output signals of type Real.
+
+# Parameters:
+- `nout=2`: Number of outputs.
+- `u_start=zeros(nout)`: Initial value for `u`.
+
+# States:
+- `u`: Value of the connector which is an array.
+""" RealOutputArray
 
 """
     SISO(;name, u_start = 0.0, y_start = 0.0)

--- a/src/Blocks/utils.jl
+++ b/src/Blocks/utils.jl
@@ -26,7 +26,7 @@ Connector with one input signal of type Real.
 - `u`: Value of the connector which is a scalar.
 """ RealInput
 
-@connector function RealInputArray(; name, nin = 2, u_start = zeros(nin))
+@connector function RealInputArray(; name, nin, u_start = zeros(nin))
     @variables u(t)[1:nin] [
         input = true,
         description = "Inner variable in RealInputArray $name"
@@ -40,7 +40,7 @@ end
 Connector with an array of input signals of type Real.
 
 # Parameters:
-- `nin=2`: Number of inputs.
+- `nin`: Number of inputs.
 - `u_start=zeros(nin)`: Guess value for `u`.
 
 # States:
@@ -75,7 +75,7 @@ Connector with one output signal of type Real.
 - `u`: Value of the connector which is a scalar.
 """ RealOutput
 
-@connector function RealOutputArray(; name, nout = 2, u_start = zeros(nout))
+@connector function RealOutputArray(; name, nout, u_start = zeros(nout))
     @variables u(t)[1:nout] [
         output = true,
         description = "Inner variable in RealOutputArray $name"
@@ -89,7 +89,7 @@ end
 Connector with an array of output signals of type Real.
 
 # Parameters:
-- `nout=2`: Number of outputs.
+- `nout`: Number of outputs.
 - `u_start=zeros(nout)`: Guess value for `u`.
 
 # States:

--- a/src/Blocks/utils.jl
+++ b/src/Blocks/utils.jl
@@ -1,18 +1,18 @@
 @connector function RealInput(; name, nin = 1, u_start = nin > 1 ? zeros(nin) : 0.0)
     nin > 1 && @warn "For inputs greater than one, use `RealInputArray`."
     if nin == 1
-        @variables u(t)=u_start [
+        @variables u(t) [
             input = true,
             description = "Inner variable in RealInput $name"
         ]
     else
-        @variables u(t)[1:nin]=u_start [
+        @variables u(t)[1:nin] [
             input = true,
             description = "Inner variable in RealInput $name"
         ]
         u = collect(u)
     end
-    ODESystem(Equation[], t, [u...], []; name = name)
+    ODESystem(Equation[], t, [u...], []; name = name, guesses = [u => u_start])
 end
 @doc """
     RealInput(;name, u_start)
@@ -20,19 +20,19 @@ end
 Connector with one input signal of type Real.
 
 # Parameters:
-- `u_start=0`: Initial value for `u`.
+- `u_start=0`: Guess value for `u`.
 
 # States:
 - `u`: Value of the connector which is a scalar.
 """ RealInput
 
 @connector function RealInputArray(; name, nin = 2, u_start = zeros(nin))
-    @variables u(t)[1:nin]=u_start [
+    @variables u(t)[1:nin] [
         input = true,
         description = "Inner variable in RealInputArray $name"
     ]
     u = collect(u)
-    ODESystem(Equation[], t, [u...], []; name = name)
+    ODESystem(Equation[], t, [u...], []; name = name, guesses = [u => u_start])
 end
 @doc """
     RealInputArray(;name, nin, u_start)
@@ -41,7 +41,7 @@ Connector with an array of input signals of type Real.
 
 # Parameters:
 - `nin=2`: Number of inputs.
-- `u_start=zeros(nin)`: Initial value for `u`.
+- `u_start=zeros(nin)`: Guess value for `u`.
 
 # States:
 - `u`: Value of the connector which is an array.
@@ -50,18 +50,18 @@ Connector with an array of input signals of type Real.
 @connector function RealOutput(; name, nout = 1, u_start = nout > 1 ? zeros(nout) : 0.0)
     nout > 1 && @warn "For outputs greater than one, use `RealOutputArray`."
     if nout == 1
-        @variables u(t)=u_start [
+        @variables u(t) [
             output = true,
             description = "Inner variable in RealOutput $name"
         ]
     else
-        @variables u(t)[1:nout]=u_start [
+        @variables u(t)[1:nout] [
             output = true,
             description = "Inner variable in RealOutput $name"
         ]
         u = collect(u)
     end
-    ODESystem(Equation[], t, [u...], []; name = name)
+    ODESystem(Equation[], t, [u...], []; name = name, guesses = [u => u_start])
 end
 @doc """
     RealOutput(;name, u_start)
@@ -69,19 +69,19 @@ end
 Connector with one output signal of type Real.
 
 # Parameters:
-- `u_start=0`: Initial value for `u`.
+- `u_start=0`: Guess value for `u`.
 
 # States:
 - `u`: Value of the connector which is a scalar.
 """ RealOutput
 
 @connector function RealOutputArray(; name, nout = 2, u_start = zeros(nout))
-    @variables u(t)[1:nout]=u_start [
+    @variables u(t)[1:nout] [
         output = true,
-        description = "Inner variable in RealOutput $name"
+        description = "Inner variable in RealOutputArray $name"
     ]
     u = collect(u)
-    ODESystem(Equation[], t, [u...], []; name = name)
+    ODESystem(Equation[], t, [u...], []; name = name, guesses = [u => u_start])
 end
 @doc """
     RealOutputArray(;name, nout, u_start)
@@ -90,7 +90,7 @@ Connector with an array of output signals of type Real.
 
 # Parameters:
 - `nout=2`: Number of outputs.
-- `u_start=zeros(nout)`: Initial value for `u`.
+- `u_start=zeros(nout)`: Guess value for `u`.
 
 # States:
 - `u`: Value of the connector which is an array.


### PR DESCRIPTION
This adds `RealInputArray` and `RealOutputArray` components
This also changes the default values of the states in the RealInput/Output/Array components to guesses.

This is useful for using symbolic vector for input/output size to be 1. Needed for using Neural Network blocks. Ref - https://github.com/SciML/ModelingToolkitNeuralNets.jl/issues/16