### PR TITLE
Switch defaults for guesses for some components

### DIFF
--- a/src/Electrical/Analog/ideal_components.jl
+++ b/src/Electrical/Analog/ideal_components.jl
@@ -246,8 +246,8 @@ Electromotoric force (electric/mechanic transformer)
         k, [description = "Transformation coefficient"]
     end
     @variables begin
-        phi(t) = 0.0, [description = "Rotation Angle"]
-        w(t) = 0.0
+        phi(t), [guess = 0.0, description = "Rotation Angle"]
+        w(t), [guess = 0.0]
     end
     @extend v, i = oneport = OnePort()
     @components begin


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

With MTK@v9 the defaults act as equations duing initialization, which can lead to overconstrained systems that can't be solved in some cases.
