### PR TITLE
Use `systems = @named begin .. end` idiom to define systems in tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,20 @@ R = 1.0
 C = 1.0
 V = 1.0
 @variables t
-@named resistor = Resistor(R = R)
-@named capacitor = Capacitor(C = C)
-@named source = Voltage()
-@named constant = Constant(k = V)
-@named ground = Ground()
+systems = @named begin
+    resistor = Resistor(R = R)
+    capacitor = Capacitor(C = C)
+    source = Voltage()
+    constant = Constant(k = V)
+    ground = Ground()
+end
 
 rc_eqs = [connect(constant.output, source.V)
           connect(source.p, resistor.p)
           connect(resistor.n, capacitor.p)
           connect(capacitor.n, source.n, ground.g)]
 
-@named rc_model = ODESystem(rc_eqs, t,
-    systems = [resistor, capacitor, constant, source, ground])
+@named rc_model = ODESystem(rc_eqs, t; systems)
 sys = structural_simplify(rc_model)
 prob = ODEProblem(sys, Pair[], (0, 10.0))
 sol = solve(prob, Tsit5())

--- a/docs/src/connectors/connections.md
+++ b/docs/src/connectors/connections.md
@@ -93,14 +93,16 @@ using ModelingToolkitStandardLibrary.Electrical, ModelingToolkit, DifferentialEq
 using ModelingToolkit: t_nounits as t
 using Plots
 
-@named resistor = Resistor(R = 1)
-@named capacitor = Capacitor(C = 1)
-@named ground = Ground()
+systems = @named begin
+    resistor = Resistor(R = 1)
+    capacitor = Capacitor(C = 1)
+    ground = Ground()
+end
 
 eqs = [connect(capacitor.p, resistor.p)
        connect(resistor.n, ground.g, capacitor.n)]
 
-@named model = ODESystem(eqs, t; systems = [resistor, capacitor, ground])
+@named model = ODESystem(eqs, t; systems)
 
 sys = structural_simplify(model)
 
@@ -133,14 +135,16 @@ Now using the Translational library based on velocity, we can see the same relat
 using ModelingToolkitStandardLibrary
 const TV = ModelingToolkitStandardLibrary.Mechanical.Translational
 
-@named damping = TV.Damper(d = 1, flange_a.v = 1)
-@named body = TV.Mass(m = 1, v = 1)
-@named ground = TV.Fixed()
+systems = @named begin
+    damping = TV.Damper(d = 1, flange_a.v = 1)
+    body = TV.Mass(m = 1, v = 1)
+    ground = TV.Fixed()
+end
 
 eqs = [connect(damping.flange_a, body.flange)
        connect(ground.flange, damping.flange_b)]
 
-@named model = ODESystem(eqs, t; systems = [damping, body, ground])
+@named model = ODESystem(eqs, t; systems)
 
 sys = structural_simplify(model)
 
@@ -166,14 +170,16 @@ Now, let's consider the position-based approach.  We can build the same model wi
 ```@example connections
 const TP = ModelingToolkitStandardLibrary.Mechanical.TranslationalPosition
 
-@named damping = TP.Damper(d = 1, va = 1, vb = 0.0)
-@named body = TP.Mass(m = 1, v = 1)
-@named ground = TP.Fixed(s_0 = 0)
+systems = @named begin
+    damping = TP.Damper(d = 1, va = 1, vb = 0.0)
+    body = TP.Mass(m = 1, v = 1)
+    ground = TP.Fixed(s_0 = 0)
+end
 
 eqs = [connect(damping.flange_a, body.flange)
        connect(ground.flange, damping.flange_b)]
 
-@named model = ODESystem(eqs, t; systems = [damping, body, ground])
+@named model = ODESystem(eqs, t; systems)
 
 sys = structural_simplify(model)
 

--- a/docs/src/tutorials/custom_component.md
+++ b/docs/src/tutorials/custom_component.md
@@ -90,15 +90,17 @@ extend(ODESystem(eqs, t, [], pars; name = name), oneport)
 The final model can now be created with the components from the library and the new custom component.
 
 ```@example components
-@named L = Inductor(L = 18)
-@named Ro = Resistor(R = 12.5e-3)
-@named G = Conductor(G = 0.565)
-@named C1 = Capacitor(C = 10, v = 4)
-@named C2 = Capacitor(C = 100)
-@named Nr = NonlinearResistor(Ga = -0.757576,
-    Gb = -0.409091,
-    Ve = 1)
-@named Gnd = Ground()
+systems = @named begin
+    L = Inductor(L = 18)
+    Ro = Resistor(R = 12.5e-3)
+    G = Conductor(G = 0.565)
+    C1 = Capacitor(C = 10, v = 4)
+    C2 = Capacitor(C = 100)
+    Nr = NonlinearResistor(Ga = -0.757576,
+        Gb = -0.409091,
+        Ve = 1)
+    Gnd = Ground()
+end
 
 connections = [connect(L.p, G.p)
                connect(G.n, Nr.p)
@@ -110,7 +112,7 @@ connections = [connect(L.p, G.p)
                connect(C2.n, Gnd.g)
                connect(Ro.n, Gnd.g)]
 
-@named model = ODESystem(connections, t, systems = [L, Ro, G, C1, C2, Nr, Gnd])
+@named model = ODESystem(connections, t; systems)
 nothing # hide
 ```
 

--- a/docs/src/tutorials/dc_motor_pi.md
+++ b/docs/src/tutorials/dc_motor_pi.md
@@ -33,20 +33,22 @@ nothing # hide
 The actual model can now be composed.
 
 ```@example dc_motor_pi
-@named ground = Ground()
-@named source = Voltage()
-@named ref = Blocks.Step(height = 1, start_time = 0)
-@named pi_controller = Blocks.LimPI(k = 1.1, T = 0.035, u_max = 10, Ta = 0.035)
-@named feedback = Blocks.Feedback()
-@named R1 = Resistor(R = R)
-@named L1 = Inductor(L = L)
-@named emf = EMF(k = k)
-@named fixed = Fixed()
-@named load = Torque()
-@named load_step = Blocks.Step(height = tau_L_step, start_time = 3)
-@named inertia = Inertia(J = J)
-@named friction = Damper(d = f)
-@named speed_sensor = SpeedSensor()
+systems = @named begin
+    ground = Ground()
+    source = Voltage()
+    ref = Blocks.Step(height = 1, start_time = 0)
+    pi_controller = Blocks.LimPI(k = 1.1, T = 0.035, u_max = 10, Ta = 0.035)
+    feedback = Blocks.Feedback()
+    R1 = Resistor(R = R)
+    L1 = Inductor(L = L)
+    emf = EMF(k = k)
+    fixed = Fixed()
+    load = Torque()
+    load_step = Blocks.Step(height = tau_L_step, start_time = 3)
+    inertia = Inertia(J = J)
+    friction = Damper(d = f)
+    speed_sensor = SpeedSensor()
+end
 
 connections = [connect(fixed.flange, emf.support, friction.flange_b)
                connect(emf.flange, friction.flange_a, inertia.flange_a)
@@ -62,23 +64,7 @@ connections = [connect(fixed.flange, emf.support, friction.flange_b)
                connect(L1.n, emf.p)
                connect(emf.n, source.n, ground.g)]
 
-@named model = ODESystem(connections, t,
-    systems = [
-        ground,
-        ref,
-        pi_controller,
-        feedback,
-        source,
-        R1,
-        L1,
-        emf,
-        fixed,
-        load,
-        load_step,
-        inertia,
-        friction,
-        speed_sensor
-    ])
+@named model = ODESystem(connections, t; systems)
 nothing # hide
 ```
 

--- a/docs/src/tutorials/rc_circuit.md
+++ b/docs/src/tutorials/rc_circuit.md
@@ -15,19 +15,20 @@ using ModelingToolkit: t_nounits as t
 R = 1.0
 C = 1.0
 V = 1.0
-@named resistor = Resistor(R = R)
-@named capacitor = Capacitor(C = C, v = 0.0)
-@named source = Voltage()
-@named constant = Constant(k = V)
-@named ground = Ground()
+systems = @named begin
+    resistor = Resistor(R = R)
+    capacitor = Capacitor(C = C, v = 0.0)
+    source = Voltage()
+    constant = Constant(k = V)
+    ground = Ground()
+end
 
 rc_eqs = [connect(constant.output, source.V)
           connect(source.p, resistor.p)
           connect(resistor.n, capacitor.p)
           connect(capacitor.n, source.n, ground.g)]
 
-@named rc_model = ODESystem(rc_eqs, t,
-    systems = [resistor, capacitor, constant, source, ground])
+@named rc_model = ODESystem(rc_eqs, t; systems)
 sys = structural_simplify(rc_model)
 prob = ODEProblem(sys, Pair[], (0, 10.0))
 sol = solve(prob, Tsit5())

--- a/docs/src/tutorials/thermal_model.md
+++ b/docs/src/tutorials/thermal_model.md
@@ -12,11 +12,13 @@ using ModelingToolkit: t_nounits as t
 
 C1 = 15
 C2 = 15
-@named mass1 = HeatCapacitor(C = C1, T = 373.15)
-@named mass2 = HeatCapacitor(C = C2, T = 273.15)
-@named conduction = ThermalConductor(G = 10)
-@named Tsensor1 = TemperatureSensor()
-@named Tsensor2 = TemperatureSensor()
+systems = @named begin
+    mass1 = HeatCapacitor(C = C1, T = 373.15)
+    mass2 = HeatCapacitor(C = C2, T = 273.15)
+    conduction = ThermalConductor(G = 10)
+    Tsensor1 = TemperatureSensor()
+    Tsensor2 = TemperatureSensor()
+end
 
 connections = [
     connect(mass1.port, conduction.port_a),
@@ -25,8 +27,7 @@ connections = [
     connect(mass2.port, Tsensor2.port)
 ]
 
-@named model = ODESystem(connections, t,
-    systems = [mass1, mass2, conduction, Tsensor1, Tsensor2])
+@named model = ODESystem(connections, t; systems)
 sys = structural_simplify(model)
 prob = ODEProblem(sys, Pair[], (0, 5.0))
 sol = solve(prob, Tsit5())


### PR DESCRIPTION
Tutorials list all systems in the `ODESystem()`-function call.  This is cumbersome, and one easily forgets to append
the list after adding the actual system and its connections.
```
systems = @named begin
 ..
end
```
is a more user friendly pattern.