### PR TITLE
Keep non-array connector variable collected

### DIFF
--- a/src/Blocks/utils.jl
+++ b/src/Blocks/utils.jl
@@ -16,8 +16,9 @@
             input = true,
             description = "Inner variable in RealInput $name"
         ]
+        u = collect(u)
     end
-    ODESystem(Equation[], t, [u], []; name = name, guesses = [u => guess])
+    ODESystem(Equation[], t, [u;], []; name = name, guesses = [u => guess])
 end
 @doc """
     RealInput(;name, guess)
@@ -74,8 +75,9 @@ Connector with an array of input signals of type Real.
             output = true,
             description = "Inner variable in RealOutput $name"
         ]
+        u = collect(u)
     end
-    ODESystem(Equation[], t, [u], []; name = name, guesses = [u => guess])
+    ODESystem(Equation[], t, [u;], []; name = name, guesses = [u => guess])
 end
 @doc """
     RealOutput(;name, guess)

--- a/src/Blocks/utils.jl
+++ b/src/Blocks/utils.jl
@@ -18,7 +18,7 @@
         ]
         u = collect(u)
     end
-    ODESystem(Equation[], t, [u;], []; name = name, guesses = [u => guess])
+    ODESystem(Equation[], t, [u;], []; name = name, guesses = [(u .=> guess);])
 end
 @doc """
     RealInput(;name, guess)
@@ -77,7 +77,7 @@ Connector with an array of input signals of type Real.
         ]
         u = collect(u)
     end
-    ODESystem(Equation[], t, [u;], []; name = name, guesses = [u => guess])
+    ODESystem(Equation[], t, [u;], []; name = name, guesses = [(u .=> guess);])
 end
 @doc """
     RealOutput(;name, guess)

--- a/src/Blocks/utils.jl
+++ b/src/Blocks/utils.jl
@@ -1,6 +1,5 @@
 @connector function RealInput(;
         name, nin = 1, u_start = nothing, guess = nin > 1 ? zeros(nin) : 0.0)
-    nin > 1 && @warn "For inputs greater than one, use `RealInputArray`."
     if u_start !== nothing
         Base.depwarn(
             "The keyword argument `u_start` is deprecated. Use `guess` instead.", :u_start)
@@ -59,7 +58,6 @@ Connector with an array of input signals of type Real.
 
 @connector function RealOutput(;
         name, nout = 1, u_start = nothing, guess = nout > 1 ? zeros(nout) : 0.0)
-    nout > 1 && @warn "For outputs greater than one, use `RealOutputArray`."
     if u_start !== nothing
         Base.depwarn(
             "The keyword argument `u_start` is deprecated. Use `guess` instead.", :u_start)

--- a/test/Blocks/test_analysis_points.jl
+++ b/test/Blocks/test_analysis_points.jl
@@ -59,7 +59,7 @@ matrices, _ = get_comp_sensitivity(sys, :plant_input)
 
 ## get_looptransfer
 
-matrices, _ = Blocks.get_looptransfer(sys, :plant_input; p = Dict(P.input.u => P.u_start))
+matrices, _ = Blocks.get_looptransfer(sys, :plant_input)
 @test matrices.A[] == -1
 @test matrices.B[] * matrices.C[] == -1 # either one negative
 @test matrices.D[] == 0
@@ -300,7 +300,7 @@ T = -CS.feedback(Kss * Pss, I(2), pos_feedback = true)
 @test CS.tf(CS.ss(matrices...)) ≈ CS.tf(T)
 
 matrices, _ = Blocks.get_looptransfer(
-    sys, :plant_input; p = Dict(P.input.u[1] => 0.0, P.input.u[2] => 0.0))
+    sys, :plant_input)
 L = Kss * Pss
 @test CS.tf(CS.ss(matrices...)) ≈ CS.tf(L)
 
@@ -353,18 +353,17 @@ To = CS.feedback(Ps * Cs)
 
 # matrices, _ = get_looptransfer(sys_outer, [:inner_plant_input, :inner_plant_output])
 matrices, _ = get_looptransfer(
-    sys_outer, :inner_plant_input; p = Dict(sys_inner.P.input.u => sys_inner.P.u_start))
+    sys_outer, :inner_plant_input)
 L = CS.ss(matrices...) |> sminreal
 @test tf(L) ≈ -tf(Cs * Ps)
 
 matrices, _ = get_looptransfer(
-    sys_outer, :inner_plant_output; p = Dict(sys_inner.add.input2.u => 0.0))
+    sys_outer, :inner_plant_output)
 L = CS.ss(matrices...) |> sminreal
 @test tf(L[1, 1]) ≈ -tf(Ps * Cs)
 
 # Calling looptransfer like below is not the intended way, but we can work out what it should return if we did so it remains a valid test
-matrices, _ = get_looptransfer(sys_outer, [:inner_plant_input, :inner_plant_output];
-    p = Dict(sys_inner.P.input.u => sys_inner.P.u_start, sys_inner.add.input2.u => 0.0))
+matrices, _ = get_looptransfer(sys_outer, [:inner_plant_input, :inner_plant_output])
 L = CS.ss(matrices...) |> sminreal
 @test tf(L[1, 1]) ≈ tf(0)
 @test tf(L[2, 2]) ≈ tf(0)

--- a/test/Blocks/utils.jl
+++ b/test/Blocks/utils.jl
@@ -1,7 +1,7 @@
 using ModelingToolkitStandardLibrary.Blocks
 using ModelingToolkit
 
-@testset "Guesses" begin
+@testset "Array Guesses" begin
     for (block, guess) in [
         (RealInputArray(; nin = 3, name = :a), zeros(3)),
         (RealOutputArray(; nout = 3, name = :a), zeros(3))
@@ -11,12 +11,12 @@ using ModelingToolkit
     end
 end
 
-@testset "Guesses" begin
+@testset "Scalarized Guesses" begin
     for (block, guess) in [
         (RealInput(; name = :a), 0.0),
         (RealInput(; nin = 3, name = :a), zeros(3)),
         (RealOutput(; name = :a), 0.0),
-        (RealOutput(; nout = 3, name = :a), zeros(3)),
+        (RealOutput(; nout = 3, name = :a), zeros(3))
     ]
         guesses = ModelingToolkit.guesses(block)
         @test guesses[@nonamespace block.u[1]] == guess[1]

--- a/test/Blocks/utils.jl
+++ b/test/Blocks/utils.jl
@@ -3,15 +3,23 @@ using ModelingToolkit
 
 @testset "Guesses" begin
     for (block, guess) in [
-        (RealInput(; name = :a), 0.0),
-        (RealInput(; nin = 3, name = :a), zeros(3)),
-        (RealOutput(; name = :a), 0.0),
-        (RealOutput(; nout = 3, name = :a), zeros(3)),
         (RealInputArray(; nin = 3, name = :a), zeros(3)),
         (RealOutputArray(; nout = 3, name = :a), zeros(3))
     ]
         guesses = ModelingToolkit.guesses(block)
         @test guesses[@nonamespace block.u] == guess
+    end
+end
+
+@testset "Guesses" begin
+    for (block, guess) in [
+        (RealInput(; name = :a), 0.0),
+        (RealInput(; nin = 3, name = :a), zeros(3)),
+        (RealOutput(; name = :a), 0.0),
+        (RealOutput(; nout = 3, name = :a), zeros(3)),
+    ]
+        guesses = ModelingToolkit.guesses(block)
+        @test guesses[@nonamespace block.u[1]] == guess[1]
     end
 end
 


### PR DESCRIPTION
The PR
- https://github.com/SciML/ModelingToolkitStandardLibrary.jl/pull/291

was breaking, in particular, the removal of
```julia
u = collect(u)
```
from `RealInput` and `RealOutput` broke Multibody.jl

Since we have both `RealInput` and `RealInputArray`, where the latter is using symbolic arrays, I propose that we keep the old behavior of `RealInput` intact, i.e., revert the breaking change.