### PR TITLE
docs: use `t_nounits` as `t`

### DIFF
--- a/docs/src/connectors/sign_convention.md
+++ b/docs/src/connectors/sign_convention.md
@@ -60,6 +60,7 @@ The flow variable (i.e. force) input component for the `Mechanical` domain is
 ```@example sign_convention
 using ModelingToolkit
 using ModelingToolkitStandardLibrary.Mechanical.Translational
+using ModelingToolkit: t_nounits as t
 
 @mtkmodel ConstantForce begin
     @parameters begin


### PR DESCRIPTION
Otherwise, `@mtkmodel` picks the default `t` with units.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
