### PR TITLE
Fix TranslationalModelica tests

### DIFF
--- a/test/Mechanical/translational_modelica.jl
+++ b/test/Mechanical/translational_modelica.jl
@@ -1,55 +1,58 @@
 using ModelingToolkit, OrdinaryDiffEq, Test
 using ModelingToolkit: t_nounits as t, D_nounits as D
 
-using ModelingToolkitStandardLibrary.Blocks
-import ModelingToolkitStandardLibrary.Mechanical.TranslationalModelica as TP
+using ModelingToolkitStandardLibrary.Blocks: Sine
+using ModelingToolkitStandardLibrary.Mechanical.TranslationalModelica: Damper, Spring, Mass,
+                                                                       Fixed, Force
 
 @testset "spring damper mass fixed" begin
-    @named damper = TP.Damper(; d = 1)
-    @named spring = TP.Spring(; c = 1, s_rel0 = 1)
-    @named mass = TP.Mass(; m = 1, v = 1)
-    @named fixed = TP.Fixed(s0 = 1)
+    @mtkmodel SpringDamperMassFixed begin
+        @components begin
+            damper = Damper(; d = 1)
+            spring = Spring(; c = 1, s_rel0 = 1)
+            mass = Mass(; m = 1, v = 1, s = 0)
+            fixed = Fixed(s0 = 1)
+        end
+        @equations begin
+            connect(spring.flange_a, mass.flange_a, damper.flange_a)
+            connect(spring.flange_b, damper.flange_b, fixed.flange)
+        end
+    end
 
-    eqs = [connect(spring.flange_a, mass.flange_a, damper.flange_a)
-           connect(spring.flange_b, damper.flange_b, fixed.flange)]
-
-    @named model = ODESystem(eqs, t; systems = [fixed, mass, spring, damper])
-
-    sys = structural_simplify(model)
-
-    foreach(println, full_equations(sys))
+    @mtkbuild sys = SpringDamperMassFixed()
 
     prob = ODEProblem(sys, [], (0, 20.0), [])
     sol = solve(prob, ImplicitMidpoint(), dt = 0.01)
 
-    @test sol[mass.v][1] == 1.0
-    @test sol[mass.v][end]≈0.0 atol=1e-4
+    @test sol[sys.mass.v][1] == 1.0
+    @test sol[sys.mass.v][end]≈0.0 atol=1e-4
 end
 
 @testset "driven spring damper mass" begin
-    @named damper = TP.Damper(; d = 1)
-    @named spring = TP.Spring(; c = 1, s_rel0 = 1)
-    @named mass = TP.Mass(; m = 1, v = 1)
-    @named fixed = TP.Fixed(; s0 = 1)
-    @named force = TP.Force()
-    @named source = Sine(frequency = 3, amplitude = 2)
+    @mtkmodel DrivenSpringDamperMass begin
+        @components begin
+            damper = Damper(; d = 1)
+            spring = Spring(; c = 1, s_rel0 = 1)
+            mass = Mass(; m = 1, v = 1, s = 0)
+            fixed = Fixed(; s0 = 1)
+            force = Force()
+            source = Sine(frequency = 3, amplitude = 2)
+        end
 
-    eqs = [connect(force.f, source.output)
-           connect(force.flange, mass.flange_a)
-           connect(spring.flange_a, mass.flange_b, damper.flange_a)
-           connect(spring.flange_b, damper.flange_b, fixed.flange)]
+        @equations begin
+            connect(force.f, source.output)
+            connect(force.flange, mass.flange_a)
+            connect(spring.flange_a, mass.flange_b, damper.flange_a)
+            connect(spring.flange_b, damper.flange_b, fixed.flange)
+        end
+    end
 
-    @named model = ODESystem(eqs, t;
-        systems = [fixed, mass, spring, damper, force, source])
-
-    sys = structural_simplify(model)
-
-    foreach(println, full_equations(sys))
+    @mtkbuild sys = DrivenSpringDamperMass()
 
     prob = ODEProblem(sys, [], (0, 20.0), [])
     sol = solve(prob, Rodas4())
 
-    lb, ub = extrema(sol(15:0.05:20, idxs = mass.v).u)
+    lb, ub = extrema(sol(15:0.05:20, idxs = sys.mass.v).u)
     @test -lb≈ub atol=1e-2
     @test -0.11 < lb < -0.1
 end


### PR DESCRIPTION
Define the models well with init pos of the mass of test components. It alleviates InitialFailure of models post removal of defaults

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
