### PR TITLE
Fix typo in `Spring` and remove more defaults

### DIFF
--- a/src/Mechanical/TranslationalPosition/components.jl
+++ b/src/Mechanical/TranslationalPosition/components.jl
@@ -133,7 +133,7 @@ end #default function
     end
 
     @named flange_a = Flange(; s = flange_a__s, f = k * (flange_a__s - flange_b__s - l))
-    @named flange_b = Flange(; s = flange_a__s, f = -k * (flange_a__s - flange_b__s - l))
+    @named flange_b = Flange(; s = flange_b__s, f = -k * (flange_a__s - flange_b__s - l))
 
     eqs = [
            #    delta_s ~ flange_a.s - flange_b.s

--- a/src/Mechanical/TranslationalPosition/sensors.jl
+++ b/src/Mechanical/TranslationalPosition/sensors.jl
@@ -70,7 +70,7 @@ Linear 1D acceleration sensor.
     end
 
     @variables begin
-        a(t) = 0.0
+        a(t)
     end
 
     @equations begin

--- a/src/Thermal/HeatTransfer/ideal_components.jl
+++ b/src/Thermal/HeatTransfer/ideal_components.jl
@@ -24,8 +24,8 @@ Lumped thermal element storing heat
         C, [description = "Heat capacity of element"]
     end
     @variables begin
-        T(t) = 273.15 + 20
-        der_T(t)
+        T(t), [guess = 273.15 + 20]
+        der_T(t), [guess = 0.0]
     end
 
     @equations begin

--- a/src/Thermal/utils.jl
+++ b/src/Thermal/utils.jl
@@ -1,6 +1,6 @@
 @connector HeatPort begin
-    T(t) = 273.15 + 20.0
-    Q_flow(t), [connect = Flow]
+    T(t), [guess = 273.15 + 20.0]
+    Q_flow(t), [guess = 0.0, connect = Flow]
 end
 Base.@doc """
     HeatPort(; name, T = 273.15 + 20.0, Q_flow = 0.0)
@@ -35,8 +35,8 @@ flow rate through the element from `port_a` to `port_b`, `Q_flow`.
         port_b = HeatPort()
     end
     @variables begin
-        dT(t)
-        Q_flow(t)
+        dT(t), [guess = 0.0]
+        Q_flow(t), [guess = 0.0]
     end
     @equations begin
         dT ~ port_a.T - port_b.T
@@ -69,8 +69,8 @@ flow rate through the element from `solid` to `fluid`, `Q_flow`.
         fluid = HeatPort()
     end
     @variables begin
-        dT(t)
-        Q_flow(t)
+        dT(t), [guess = 0.0]
+        Q_flow(t), [guess = 0.0]
     end
     @equations begin
         dT ~ solid.T - fluid.T


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

@avinashresearch1 Are the changes in `Thermal` appropriate?
