### PR TITLE
add parameters to PID controllers

### DIFF
--- a/src/Blocks/continuous.jl
+++ b/src/Blocks/continuous.jl
@@ -633,13 +633,13 @@ See also [`StateSpace`](@ref) which handles MIMO systems, as well as [ControlSys
             description = "Denominator coefficients of transfer function (e.g., `s² + 2ωs + ω^2` is specified as [1, 2ω, ω^2])"
         ]
         bb[1:(nbb + nb)] = [zeros(nbb); b]
-        d = bb[1] / a[1], [description = "Direct feedthrough gain"]
     end
+    d = bb[1] / a[1]# , [description = "Direct feedthrough gain"]
 
     a = collect(a)
-    @parameters a_end = ifelse(a[end] > 100 * symbolic_eps(sqrt(a' * a)), a[end], 1.0)
+    a_end = ifelse(a[end] > 100 * symbolic_eps(sqrt(a' * a)), a[end], 1.0)
 
-    pars = [collect(b); a; collect(bb); d; a_end]
+    pars = [collect(b); a; collect(bb)]
     @variables begin
         x(t)[1:nx] = zeros(nx),
         [description = "State of transfer function on controller canonical form"]

--- a/src/Blocks/nonlinear.jl
+++ b/src/Blocks/nonlinear.jl
@@ -19,7 +19,7 @@ Limit the range of a signal.
 @component function Limiter(; name, y_max, y_min = y_max > 0 ? -y_max : -Inf)
     @symcheck y_max ≥ y_min || throw(ArgumentError("`y_min` must be smaller than `y_max`"))
     m = (y_max + y_min) / 2
-    @named siso = SISO(u_start = m, y_start = m) # Default signals to center of saturation to minimize risk of saturation while linearizing etc.
+    siso = SISO(u_start = m, y_start = m, name = :siso) # Default signals to center of saturation to minimize risk of saturation while linearizing etc.
     @unpack u, y = siso
     pars = @parameters y_max=y_max [description = "Maximum allowed output of Limiter $name"] y_min=y_min [
         description = "Minimum allowed output of Limiter $name"

--- a/test/Blocks/continuous.jl
+++ b/test/Blocks/continuous.jl
@@ -430,7 +430,7 @@ end
         @named pt1 = TransferFunction(b = [1.2], a = [3.14, 1])
         @named iosys = ODESystem(connect(c.output, pt1.input), t, systems = [pt1, c])
         sys = structural_simplify(iosys)
-        prob = ODEProblem(sys, Pair[pt1.a_end => 1], (0.0, 100.0))
+        prob = ODEProblem(sys, Pair[], (0.0, 100.0))
         sol = solve(prob, Rodas4())
         @test sol.retcode == Success
         @test sol[pt1.output.u]≈pt1_func.(sol.t, 1.2, 3.14) atol=1e-3
@@ -440,7 +440,7 @@ end
         @named pt1 = TransferFunction(b = [1.2], a = [3.14, 0])
         @named iosys = ODESystem(connect(c.output, pt1.input), t, systems = [pt1, c])
         sys = structural_simplify(iosys)
-        prob = ODEProblem(sys, Pair[pt1.a_end => 1], (0.0, 100.0))
+        prob = ODEProblem(sys, Pair[], (0.0, 100.0))
         sol = solve(prob, Rodas4())
         @test sol.retcode == Success
         @test sol[pt1.output.u] ≈ sol.t .* (1.2 / 3.14)
@@ -464,7 +464,7 @@ end
         @named pt1 = TransferFunction(b = [w^2], a = [1, 2d * w, w^2])
         @named iosys = ODESystem(connect(c.output, pt1.input), t, systems = [pt1, c])
         sys = structural_simplify(iosys)
-        prob = ODEProblem(sys, Pair[pt1.a_end => 1], (0.0, 100.0))
+        prob = ODEProblem(sys, Pair[], (0.0, 100.0))
         sol = solve(prob, Rodas4())
         @test sol.retcode == Success
         @test sol[pt1.output.u]≈pt2_func.(sol.t, k, w, d) atol=1e-3
@@ -474,7 +474,7 @@ end
         @named pt1 = TransferFunction(b = [1, 0], a = [1, 1])
         @named iosys = ODESystem(connect(c.output, pt1.input), t, systems = [pt1, c])
         sys = structural_simplify(iosys)
-        prob = ODEProblem(sys, Pair[pt1.a_end => 1], (0.0, 100.0))
+        prob = ODEProblem(sys, Pair[], (0.0, 100.0))
         sol = solve(prob, Rodas4())
         @test sol.retcode == Success
         @test sol[pt1.output.u]≈1 .- pt1_func.(sol.t, 1, 1) atol=1e-3
@@ -484,7 +484,7 @@ end
         @named pt1 = TransferFunction(b = [2.7], a = [pi])
         @named iosys = ODESystem(connect(c.output, pt1.input), t, systems = [pt1, c])
         sys = structural_simplify(iosys)
-        prob = ODEProblem(sys, Pair[pt1.a_end => 1], (0.0, 100.0))
+        prob = ODEProblem(sys, Pair[], (0.0, 100.0))
         sol = solve(prob, Rodas4())
         @test sol.retcode == Success
         @test all(==(2.7 / pi), sol[pt1.output.u])

--- a/test/Mechanical/translational_modelica.jl
+++ b/test/Mechanical/translational_modelica.jl
@@ -105,5 +105,5 @@ end
     prob = ODEProblem(sys, [], (0, 2pi))
     sol = solve(prob, Rodas4())
     tv = 0:0.1:(2pi)
-    @test sol(tv, idxs = sys.mass.s)≈@.(2sin(2pi * tv * 3)) atol=1e-2
+    @test sol(tv, idxs = sys.mass.s).u ≈ @.(2sin(2pi * tv * 3)) atol=1e-2
 end

--- a/test/Mechanical/translational_modelica.jl
+++ b/test/Mechanical/translational_modelica.jl
@@ -105,5 +105,5 @@ end
     prob = ODEProblem(sys, [], (0, 2pi))
     sol = solve(prob, Rodas4())
     tv = 0:0.1:(2pi)
-    @test sol(tv, idxs = sys.mass.s).u ≈ @.(2sin(2pi * tv * 3)) atol=1e-2
+    @test sol(tv, idxs = sys.mass.s).u≈@.(2sin(2pi * tv * 3)) atol=1e-2
 end


### PR DESCRIPTION
@AayushSabharwal some tests are failing with errors like this
```julia
LimPI: Error During Test at /home/fredrikb/.julia/dev/ModelingToolkitStandardLibrary/test/Blocks/continuous.jl:232
  Got exception outside of a @test
  Could not evaluate value of parameter pi_controller_lim₊limiter₊u_start. Missing values for variables in expression (1//2)*(u_max + u_min).
```
There are default values for the parameters `u_max, u_min`, so it should be possible to figure out the default for `pi_controller_lim₊limiter₊u_start`