### PR TITLE
[WIP] Add Latexify extension and AnalysisPoint support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,12 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 PreallocationTools = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
+[weakdeps]
+Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+
+[extensions]
+ModelingToolkitStandardLibraryLatexify = "Latexify"
+
 [compat]
 Aqua = "0.8"
 ChainRulesCore = "1.24"
@@ -21,6 +27,7 @@ DataInterpolations = "6"
 ForwardDiff = "0.10"
 DiffEqBase = "6.152"
 IfElse = "0.1"
+Latexify = "0.16"
 LinearAlgebra = "1.10"
 Optimization = "4"
 ModelingToolkit = "9.47"

--- a/ext/ModelingToolkitStandardLibraryLatexifyExt.jl
+++ b/ext/ModelingToolkitStandardLibraryLatexifyExt.jl
@@ -1,0 +1,14 @@
+module ModelingToolkitStandardLibraryLatexifyExt
+
+using ModelingToolkitStandardLibrary
+using Latexify
+
+@latexrecipe function f(n::AnalysisPoint)
+    env --> :equation
+    cdot --> false
+    index --> :subscript
+
+    return nameof(n)
+end
+
+end


### PR DESCRIPTION
Though it's really weird... it completely ignores the recipe. MWE:

```julia
using ModelingToolkit
using ModelingToolkit: t_nounits as t
using ModelingToolkitStandardLibrary.Electrical
using ModelingToolkitStandardLibrary.Mechanical.Rotational
using ModelingToolkitStandardLibrary.Blocks
using OrdinaryDiffEq
using Plots

@mtkmodel DCMotor begin
    @parameters begin
        R = 0.5, [description = "Armature resistance"] # Ohm
        L = 4.5e-3, [description = "Armature inductance"] # H
        k = 0.5, [description = "Motor constant"] # N.m/A
        J = 0.02, [description = "Inertia"] # kg.m²
        f = 0.01, [description = "Friction factor"] # N.m.s/rad
        tau_L_step = -0.3, [description = "Amplitude of the load torque step"] # N.m
    end
    @components begin
        ground = Ground()
        source = Voltage()
        ref = Blocks.Step(height = 1, start_time = 0)
        pi_controller = Blocks.LimPI(k = 1.1, T = 0.035, u_max = 10, Ta = 0.035)
        feedback = Blocks.Feedback()
        R1 = Resistor(R = R)
        L1 = Inductor(L = L)
        emf = EMF(k = k)
        fixed = Fixed()
        load = Torque()
        load_step = Blocks.Step(height = tau_L_step, start_time = 3)
        inertia = Inertia(J = J)
        friction = Damper(d = f)
        speed_sensor = SpeedSensor()
    end
    @equations begin
        connect(fixed.flange, emf.support, friction.flange_b)
        connect(emf.flange, friction.flange_a, inertia.flange_a)
        connect(inertia.flange_b, load.flange)
        connect(inertia.flange_b, speed_sensor.flange)
        connect(load_step.output, load.tau)
        connect(ref.output, feedback.input1)
        connect(speed_sensor.w, :y, feedback.input2)
        connect(feedback.output, pi_controller.err_input)
        connect(pi_controller.ctr_output, :u, source.V)
        connect(source.p, R1.p)
        connect(R1.n, L1.p)
        connect(L1.n, emf.p)
        connect(emf.n, source.n, ground.g)
    end
end

@named model = DCMotor()

sys = structural_simplify(model)
connect(sys.speed_sensor.w, :y, sys.feedback.input2)

using Latexify

@latexrecipe function f(n::AnalysisPoint)
    env --> :equation
    cdot --> false
    index --> :subscript
    return nameof(n)
end

latexify(connect(sys.speed_sensor.w, :y, sys.feedback.input2))
```

```
julia> latexify(connect(sys.speed_sensor.w, :y, sys.feedback.input2))
ERROR: AssertionError: latexify does not support objects of type AnalysisPoint.
Stacktrace:
  [1] _latexraw(args::AnalysisPoint; kwargs::@Kwargs{…})
    @ Latexify ~/.julia/packages/Latexify/ieukI/src/latexraw.jl:109
  [2] process_latexify(args::Num; kwargs::@Kwargs{convert_unicode::Bool, index::Symbol, env::Symbol})
    @ Latexify ~/.julia/packages/Latexify/ieukI/src/latexify_function.jl:49
  [3] process_latexify
    @ ~/.julia/packages/Latexify/ieukI/src/latexify_function.jl:40 [inlined]
  [4] latexraw
    @ ~/.julia/packages/Latexify/ieukI/src/latexraw.jl:58 [inlined]
  [5] (::Latexify.var"#64#66"{@Kwargs{convert_unicode::Bool, index::Symbol, env::Symbol}})(i::Num)
    @ Latexify ~/.julia/packages/Latexify/ieukI/src/latexoperation.jl:21
  [6] iterate
    @ ./generator.jl:47 [inlined]
  [7] _collect(c::Vector{…}, itr::Base.Generator{…}, ::Base.EltypeUnknown, isz::Base.HasShape{…})
    @ Base ./array.jl:854
  [8] collect_similar
    @ ./array.jl:763 [inlined]
  [9] map
    @ ./abstractarray.jl:3285 [inlined]
 [10] latexoperation(ex::Expr, prevOp::Vector{Symbol}; kwargs::@Kwargs{convert_unicode::Bool, index::Symbol, env::Symbol})
    @ Latexify ~/.julia/packages/Latexify/ieukI/src/latexoperation.jl:21
 [11] latexoperation
    @ ~/.julia/packages/Latexify/ieukI/src/latexoperation.jl:9 [inlined]
 [12] (::Latexify.var"#recurseexp!#44"{Bool, @Kwargs{index::Symbol, env::Symbol}})(ex::Expr)
    @ Latexify ~/.julia/packages/Latexify/ieukI/src/latexraw.jl:98
 [13] _latexraw(inputex::Expr; convert_unicode::Bool, kwargs::@Kwargs{index::Symbol, env::Symbol})
    @ Latexify ~/.julia/packages/Latexify/ieukI/src/latexraw.jl:102
 [14] process_latexify(args::Expr; kwargs::@Kwargs{index::Symbol, env::Symbol})
    @ Latexify ~/.julia/packages/Latexify/ieukI/src/latexify_function.jl:49
 [15] process_latexify
    @ ~/.julia/packages/Latexify/ieukI/src/latexify_function.jl:40 [inlined]
 [16] latexraw
    @ ~/.julia/packages/Latexify/ieukI/src/latexraw.jl:58 [inlined]
 [17] _latexequation(eq::Expr; starred::Bool, kwargs::@Kwargs{index::Symbol, env::Symbol})
    @ Latexify ~/.julia/packages/Latexify/ieukI/src/latexequation.jl:5
 [18] process_latexify(args::Equation; kwargs::@Kwargs{})
    @ Latexify ~/.julia/packages/Latexify/ieukI/src/latexify_function.jl:49
 [19] process_latexify
    @ ~/.julia/packages/Latexify/ieukI/src/latexify_function.jl:40 [inlined]
 [20] latexify(args::Equation; kwargs::@Kwargs{})
    @ Latexify ~/.julia/packages/Latexify/ieukI/src/latexify_function.jl:27
 [21] latexify(args::Equation)
    @ Latexify ~/.julia/packages/Latexify/ieukI/src/latexify_function.jl:25
 [22] top-level scope
    @ REPL[14]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

@gustaphe do you know why this recipe is missed?
