### PR TITLE
Add capacitor initial voltage to README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ The following is the [RC Circuit Demonstration](https://docs.sciml.ai/ModelingTo
 using ModelingToolkit, OrdinaryDiffEq, Plots
 using ModelingToolkitStandardLibrary.Electrical
 using ModelingToolkitStandardLibrary.Blocks: Constant
+using ModelingToolkit: t_nounits as t
 
 R = 1.0
 C = 1.0
 V = 1.0
-@variables t
 systems = @named begin
     resistor = Resistor(R = R)
     capacitor = Capacitor(C = C, v = 0.0)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ V = 1.0
 @variables t
 systems = @named begin
     resistor = Resistor(R = R)
-    capacitor = Capacitor(C = C)
+    capacitor = Capacitor(C = C, v = 0.0)
     source = Voltage()
     constant = Constant(k = V)
     ground = Ground()


### PR DESCRIPTION
Unless initial condition for capacitor initial voltage is given, `ODEProblem` errors
```
┌ Warning: Initialization system is underdetermined. 0 equations for 1 unknowns. Initialization will default to using least squares. To suppress this warning pass warninitializedetermined = false. To make this
│ warning into an error, pass fully_determined = true
└ @ ModelingToolkit C:\Users\jaakkor2\.julia\packages\ModelingToolkit\zfOUk\src\systems\diffeqs\abstractodesystem.jl:1294
┌ Warning: Did not converge after maxiters = 0 substitutions. Either there is a cycle in the rules or maxiters needs to be higher.
└ @ Symbolics C:\Users\jaakkor2\.julia\packages\Symbolics\8MbnV\src\variable.jl:546
ERROR: Found symbolic value -capacitor₊p₊v(t) for variable resistor₊p₊i(t). You may be missing an initial condition or have cyclic initial conditions. If this is intended, pass `symbolic_u0 = true`. In case the initial conditions are not cyclic but require more substitutions to resolve, increase `substitution_limit`. To report cycles in initial conditions of unknowns/parameters, pass `warn_cyclic_dependency = true`. If the cycles are still not reported, you may need to pass a larger value for `circular_dependency_max_cycle_length` or `circular_dependency_max_cycles`.
```

Initial condition `v=0.0` is given here
https://github.com/SciML/ModelingToolkitStandardLibrary.jl/blob/v2.17.0/docs/src/tutorials/rc_circuit.md#L23 and here
https://github.com/SciML/ModelingToolkitStandardLibrary.jl/blob/v2.17.0/test/Electrical/analog.jl#L91

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
