### PR TITLE
refactor: only load analysis points if not defined in ModelingToolkit

### DIFF
--- a/src/Blocks/Blocks.jl
+++ b/src/Blocks/Blocks.jl
@@ -29,6 +29,8 @@ include("continuous.jl")
 
 export AnalysisPoint, get_sensitivity, get_comp_sensitivity,
        get_looptransfer, open_loop
-include("analysis_points.jl")
+@static if !isdefined(ModelingToolkit, :AnalysisPoint)
+    include("analysis_points.jl")
+end
 
 end


### PR DESCRIPTION
This prevents conflicting exports and overwritten method definitions when using Stdlib with `AnalysisPoint` and related infrastructure defined in https://github.com/SciML/ModelingToolkit.jl/pull/3285.