### PR TITLE
Fixes issue #234 using same inputs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ PreallocationTools = "0.4.23"
 SafeTestsets = "0.1"
 SciMLStructures = "1.4.2"
 SymbolicIndexingInterface = "0.3.28"
-Symbolics = "6.14"
+Symbolics = "=6.29.2"
 Test = "1"
 julia = "1.10"
 

--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ PreallocationTools = "0.4.23"
 SafeTestsets = "0.1"
 SciMLStructures = "1.4.2"
 SymbolicIndexingInterface = "0.3.28"
-Symbolics = "=6.29.2"
+Symbolics = "6.14"
 Test = "1"
 julia = "1.10"
 

--- a/src/Thermal/HeatTransfer/sources.jl
+++ b/src/Thermal/HeatTransfer/sources.jl
@@ -28,9 +28,9 @@ the component FixedHeatFlow is connected, if parameter `Q_flow` is positive.
     end
 
     @equations begin
-        port.Q_flow ~ IfElse.ifelse(alpha == 0.0, 
+        port.Q_flow ~ ifelse(alpha == 0.0, 
                                    -Q_flow,  # Simplified equation when alpha is 0
-                                   -Q_flow * (1 + alpha * (port.T - T_ref)))  # Temperature-dependent equation
+                                   -Q_flow * (1 + alpha * (port.T - T_ref)))
     end
 end
 

--- a/src/Thermal/HeatTransfer/sources.jl
+++ b/src/Thermal/HeatTransfer/sources.jl
@@ -28,7 +28,9 @@ the component FixedHeatFlow is connected, if parameter `Q_flow` is positive.
     end
 
     @equations begin
-        port.Q_flow ~ -Q_flow * (1 + alpha * (port.T - T_ref))
+        port.Q_flow ~ IfElse.ifelse(alpha == 0.0, 
+                                   -Q_flow,  # Simplified equation when alpha is 0
+                                   -Q_flow * (1 + alpha * (port.T - T_ref)))  # Temperature-dependent equation
     end
 end
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

- Fixes issue #234
- The issue seems to be that if alpha is 0, the symbolic compiler will create an equation with 0 division
- This has been solved using an ifelse statement
- The functionality remains the same including inputs
- Not sure whether to update the docstring, so this remains as-is
- A MWE test is adapted from issue #234 as follows:

```julia 
using OrdinaryDiffEq, ModelingToolkit
using ModelingToolkitStandardLibrary.Thermal
using ModelingToolkit: t_nounits as t

@mtkmodel TestModel begin
    
    @components begin
        temp = FixedTemperature(T=300)
        heatflow = FixedHeatFlow(Q_flow=-1.0)
        wall = ThermalResistor(R=1)
    end

    @equations begin
        connect(temp.port, wall.port_a)
        connect(wall.port_b, heatflow.port)
    end

end

@mtkbuild test_model = TestModel()
for eq in observed(test_model)
    println(eq)
end
prob = ODEProblem(test_model, Pair[], (0, 10.0))
sol = solve(prob)
```

**Output before:**

```
temp₊port₊T(t) ~ temp₊T
heatflow₊port₊Q_flow(t) ~ wall₊Q_flow(t)
wall₊port_a₊Q_flow(t) ~ wall₊Q_flow(t)
wall₊port_b₊Q_flow(t) ~ -wall₊Q_flow(t)
temp₊port₊Q_flow(t) ~ -wall₊Q_flow(t)
wall₊port_a₊T(t) ~ temp₊port₊T(t)
heatflow₊port₊T(t) ~ (-heatflow₊port₊Q_flow(t) + heatflow₊Q_flow*(-1 + heatflow₊T_ref*heatflow₊alpha)) / (heatflow₊Q_flow*heatflow₊alpha)
wall₊dT(t) ~ temp₊port₊T(t) - heatflow₊port₊T(t)
wall₊port_b₊T(t) ~ heatflow₊port₊T(t)
retcode: InitialFailure
Interpolation: 3rd order Hermite
t: 1-element Vector{Float64}:
 0.0
u: 1-element Vector{Vector{Float64}}:
 [NaN]
```

**Output after:**

```
temp₊port₊T(t) ~ temp₊T
heatflow₊port₊T(t) ~ -wall₊dT(t) + temp₊port₊T(t)
wall₊port_a₊T(t) ~ temp₊port₊T(t)
heatflow₊port₊Q_flow(t) ~ ifelse(heatflow₊alpha == 0.0, -heatflow₊Q_flow, heatflow₊Q_flow*(-1 + (heatflow₊T_ref - heatflow₊port₊T(t))*heatflow₊alpha))
wall₊port_b₊T(t) ~ heatflow₊port₊T(t)
wall₊Q_flow(t) ~ heatflow₊port₊Q_flow(t)
wall₊port_a₊Q_flow(t) ~ wall₊Q_flow(t)
wall₊port_b₊Q_flow(t) ~ -wall₊Q_flow(t)
temp₊port₊Q_flow(t) ~ -wall₊Q_flow(t)
retcode: Success
Interpolation: 3rd order Hermite
t: 9-element Vector{Float64}:
  0.0
  1.0e-6
  1.1e-5
  0.00011099999999999999
  ⋮
  0.11111099999999996
  1.1111109999999995
 10.0
u: 9-element Vector{Vector{Float64}}:
 [1.0]
 [1.0]
 [1.0]
 [1.0]
 ⋮
 [1.0]
 [1.0]
 [1.0]
 ```
This MWE has been added as a test, which passes