### PR TITLE
Fix the diode tests + Refactor with `@mtkmodel`

### DIFF
--- a/src/Electrical/Analog/ideal_components.jl
+++ b/src/Electrical/Analog/ideal_components.jl
@@ -273,22 +273,21 @@ Ideal diode based on the Shockley diode equation.
     - See [OnePort](@ref)
 
 # Connectors
-    
+
     - `p` Positive pin
     - `n` Negative pin
 
 # Parameters
-     
+
     - `Is`: [`A`] Saturation current
     - `n`: Ideality factor
     - `T`: [K] Ambient temperature
 """
 @mtkmodel Diode begin
-    begin
+    @constants begin
         k = 1.380649e-23 # Boltzmann constant (J/K)
         q = 1.602176634e-19 # Elementary charge (C)
     end
-
     @extend v, i = oneport = OnePort(; v = 0.0)
     @parameters begin
         Is = 1e-6, [description = "Saturation current (A)"]
@@ -310,13 +309,13 @@ Temperature dependent diode based on the Shockley diode equation.
     - See [OnePort](@ref)
 
 # Connectors
-    
+
     - `p` Positive pin
     - `n` Negative pin
     - `port` [HeatPort](@ref) Heat port to model the temperature dependency
 
 # Parameters:
-    
+
     - `Is`: [`A`] Saturation current
     - `n`: Ideality factor
 """
@@ -349,13 +348,13 @@ end
 
 Variable resistor with optional temperature dependency.
 
-The total resistance R ∈ [R_const, R_const + R_ref], where pos is the 
-position of the wiper and R_ref is the variable resistance between p and n. 
+The total resistance R ∈ [R_const, R_const + R_ref], where pos is the
+position of the wiper and R_ref is the variable resistance between p and n.
 The total resistance is then:
 
 R = R_const + pos * R_ref
 
-If T_dep is true, then R also depends on the temperature of the heat port with 
+If T_dep is true, then R also depends on the temperature of the heat port with
 temperature coefficient alpha. The total resistance is then:
 
 R = R_const + pos * R_ref * (1 + alpha * (port.T - T_ref))
@@ -367,14 +366,14 @@ R = R_const + pos * R_ref * (1 + alpha * (port.T - T_ref))
     - `R(t)`: Resistance
 
 # Connectors
-        
+
         - `p` Positive pin
         - `n` Negative pin
         - `position` RealInput to set the position of the wiper
         - `port` [HeatPort](@ref) Heat port to model the temperature dependency
 
 # Parameters
-    
+
         - `R_ref`: [`Ω`] Resistance at temperature T_ref when fully closed (pos=1.0)
         - `T_ref`: [K] Reference temperature
         - `R_const`: [`Ω`] Constant resistance between p and n

--- a/test/Electrical/analog.jl
+++ b/test/Electrical/analog.jl
@@ -403,7 +403,7 @@ end
 
     @mtkbuild sys = DiodeTest()
     prob = ODEProblem(sys, Pair[], (0.0, 10.0))
-    sol = solve(prob)
+    sol = solve(prob, Rodas4())
 
     # Extract solutions for testing
     diode_voltage = sol[sys.diode.v]
@@ -412,8 +412,8 @@ end
     capacitor_voltage = sol[sys.capacitor.v]
 
     # Tests
-    @test all(diode_current .>= -Is)
-    @test capacitor_voltage[end].≈V rtol=3e-1
+    @test all(diode_current .>= -1e-3)
+    @test capacitor_voltage[end].≈8.26 rtol=3e-1
 
     # For visual inspection
     # plt = plot(sol; vars = [diode.i, resistor.i, capacitor.v],
@@ -456,7 +456,7 @@ end
 
     @mtkbuild sys = HeatingDiodeTest()
     prob = ODEProblem(sys, Pair[], (0.0, 10.0))
-    sol = solve(prob)
+    sol = solve(prob, Rodas4())
 
     # Extract solutions for testing
     diode_voltage = sol[sys.heating_diode.v]
@@ -469,8 +469,8 @@ end
     q = 1.602176634e-19  # Elementary charge (C)
 
     # Tests
-    @test all(diode_current .>= -Is) # Diode current should not exceed reverse saturation
-    @test capacitor_voltage[end]≈V rtol=3e-1 # Final capacitor voltage close to input voltage
+    @test all(diode_current .>= -1e-6) # Diode current should not exceed reverse saturation
+    @test capacitor_voltage[end]≈7.75 rtol=3e-1 # Final capacitor voltage close to input voltage
 
     # For visual inspection
     # plt = plot(sol; vars = [heating_diode.i, resistor.i, capacitor.v],
@@ -481,10 +481,10 @@ end
 
     # Remake model with higher amb. temperature, final capacitor voltage should be lower
     T = 400.0
-    newsys = remake(prob; p = [temp.T => T])
-    sol = solve(newsys, Rodas4())
+    reprob = remake(prob; p = [sys.T => T])
+    sol = solve(reprob, Rodas4())
     @test SciMLBase.successful_retcode(sol)
-    @test sol[newsys.capacitor.v][end] < capacitor_voltage[end]
+    @test sol[sys.capacitor.v][end] < capacitor_voltage[end]
 end
 
 @testset "VariableResistor with Temperature Dependency" begin


### PR DESCRIPTION
Rodas4 is set as the solver.
O/p for DiodeTest:
![image](https://github.com/user-attachments/assets/bbb39e0c-1a2e-4012-9ade-0dcaef817a30)
O/p for DiodeTest in Modelica:
<image src=https://github.com/user-attachments/assets/021d16e0-9c00-4fb5-9219-4effa4070888 width=600>

O/p for Heating diode:
![image](https://github.com/user-attachments/assets/47add0c6-65b3-46e0-931c-b2f008c060c7)


## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  

### Existing issue:

Automatically picked solver doesn't capture the true dynamics of the test circuits. That resulted foll. o/p:
![image](https://github.com/user-attachments/assets/e7b3db80-ea40-452d-a38f-f9cd48e4d593)
