### PR TITLE
DOCS: Connect the clock in causal direction

### DIFF
--- a/docs/src/tutorials/input_component.md
+++ b/docs/src/tutorials/input_component.md
@@ -114,7 +114,7 @@ function MassSpringDamperSystem(data, time; name)
     @named model = MassSpringDamper()
 
     eqs = [connect(model.input, src.output)
-           connect(src.input, clk.output)]
+           connect(clk.output, src.input)]
 
     ODESystem(eqs, t; name, systems = [src, clk, model])
 end

--- a/docs/src/tutorials/input_component.md
+++ b/docs/src/tutorials/input_component.md
@@ -51,7 +51,7 @@ function MassSpringDamperSystem(data, time; name)
     @named clk = ContinuousClock()
     @named model = MassSpringDamper()
 
-    eqs = [connect(src.input, clk.output)
+    eqs = [connect(clk.output, src.input)
            connect(src.output, model.input)]
 
     ODESystem(eqs, t, [], []; name, systems = [src, clk, model])


### PR DESCRIPTION
This is really a question maskerading as a PR, but given that `?connect` says:

>   PLEASE NOTE: The connection is assumed to be causal, meaning that
> 
>   `connect(C.output, :plant_input, P.input)`
> 
>   is correct, whereas
> 
>   `connect(P.input, :plant_input, C.output)`
> 
>   typically is not (unless the model is an inverse model).

I'm assuming that `connect(src.input, clk.output)` yields the right answer, but as a casual reader trying to figure out what a `ContinuousClock` is, the causal direction helps understand what's going on.