### PR TITLE
RealOutputs for thermal sensors

### DIFF
--- a/src/Thermal/HeatTransfer/sensors.jl
+++ b/src/Thermal/HeatTransfer/sensors.jl
@@ -7,23 +7,18 @@ This is an ideal absolute temperature sensor which returns the temperature of th
 signal. The sensor itself has no thermal interaction with whatever it is connected to. Furthermore, no thermocouple-like
 lags are associated with this sensor model.
 
-# States:
-
-  - `T(t)`: [`K`] Absolute temperature
-
 # Connectors:
 
-  - `port`
+  - `port`: [HeatPort](@ref) Thermal port from which sensor information shall be measured
+  - `T`: [RealOutput](@ref) [K] Absolute temperature of port
 """
 @mtkmodel TemperatureSensor begin
     @components begin
         port = HeatPort()
-    end
-    @variables begin
-        T(t)
+        T = RealOutput()
     end
     @equations begin
-        T ~ port.T
+        T.u ~ port.T
         port.Q_flow ~ 0
     end
 end
@@ -36,25 +31,20 @@ Relative Temperature sensor.
 The relative temperature `port_a.T - port_b.T` is determined between the two ports of this component and is provided as
 output signal in kelvin.
 
-# States:
-
-  - `T(t)`: [`K`] Relative temperature `a.T - b.T`
-
 # Connectors:
 
-  - `port_a`
-  - `port_b`
+  - `port_a`: [HeatPort](@ref) Thermal port from which sensor information shall be measured
+  - `port_b`: [HeatPort](@ref) Thermal port from which sensor information shall be measured
+  - `T`: [RealOutput](@ref) [K] Relative temperature `a.T - b.T`
 """
 @mtkmodel RelativeTemperatureSensor begin
     @components begin
         port_a = HeatPort()
         port_b = HeatPort()
-    end
-    @variables begin
-        T(t)
+        T = RealOutput()
     end
     @equations begin
-        T ~ port_a.T - port_b.T
+        T.u ~ port_a.T - port_b.T
         port_a.Q_flow ~ 0
         port_b.Q_flow ~ 0
     end
@@ -70,26 +60,21 @@ is the amount that passes through this sensor while keeping the temperature drop
 model, so it does not absorb any energy, and it has no direct effect on the thermal response of a system it is included in.
 The output signal is positive, if the heat flows from `port_a` to `port_b`.
 
-# States:
-
-  - `Q_flow(t)`: [`W`] Heat flow from `port_a` to `port_b`
-
 # Connectors:
 
-  - `port_a`
-  - `port_b`
+  - `port_a`: [HeatPort](@ref) Thermal port from which sensor information shall be measured
+  - `port_b`: [HeatPort](@ref) Thermal port from which sensor information shall be measured
+  - `Q_flow`: [RealOutput](@ref) [W] Heat flow from `port_a` to `port_b` 
 """
 @mtkmodel HeatFlowSensor begin
     @components begin
         port_a = HeatPort()
         port_b = HeatPort()
-    end
-    @variables begin
-        Q_flow(t)
+        Q_flow = RealOutput()
     end
     @equations begin
         port_a.T ~ port_b.T
         port_a.Q_flow + port_b.Q_flow ~ 0
-        Q_flow ~ port_a.Q_flow
+        Q_flow.u ~ port_a.Q_flow
     end
 end

--- a/test/Thermal/motor.jl
+++ b/test/Thermal/motor.jl
@@ -1,4 +1,4 @@
-using ModelingToolkit, OrdinaryDiffEqDefault, Test
+using ModelingToolkit, Test
 using ModelingToolkitStandardLibrary.Thermal
 using ModelingToolkitStandardLibrary.Blocks
 
@@ -47,10 +47,10 @@ using ModelingToolkitStandardLibrary.Blocks
 
     # plot(sol; vars=[T_winding.T, T_core.T])
     @test SciMLBase.successful_retcode(sol)
-    @test sol[motor.T_winding.T] == sol[motor.winding.T]
-    @test sol[motor.T_core.T] == sol[motor.core.T]
+    @test sol[motor.T_winding.T.u] == sol[motor.winding.T]
+    @test sol[motor.T_core.T.u] == sol[motor.core.T]
     @test sol[-motor.core.port.Q_flow] ≈
           sol[motor.coreLosses.port.Q_flow + motor.convection.solid.Q_flow + motor.winding2core.port_b.Q_flow]
-    @test sol[motor.T_winding.T][end] >= 500 # not good but better than nothing
-    @test sol[motor.T_core.T] <= sol[motor.T_winding.T]
+    @test sol[motor.T_winding.T.u][end] >= 500 # not good but better than nothing
+    @test sol[motor.T_core.T.u] <= sol[motor.T_winding.T.u]
 end

--- a/test/Thermal/piston.jl
+++ b/test/Thermal/piston.jl
@@ -1,4 +1,4 @@
-using ModelingToolkit, OrdinaryDiffEqDefault, Test
+using ModelingToolkit, Test
 using ModelingToolkitStandardLibrary.Thermal
 using ModelingToolkitStandardLibrary.Blocks
 

--- a/test/Thermal/thermal.jl
+++ b/test/Thermal/thermal.jl
@@ -29,7 +29,7 @@ using OrdinaryDiffEq: ReturnCode.Success
     # Check if Relative temperature sensor reads the temperature of heat capacitor
     # when connected to a thermal conductor and a fixed temperature source
     @test SciMLBase.successful_retcode(sol)
-    @test sol[reltem_sensor.T] + sol[tem_src.port.T] == sol[mass1.T] + sol[th_conductor.dT]
+    @test sol[reltem_sensor.T.u] + sol[tem_src.port.T] == sol[mass1.T] + sol[th_conductor.dT]
 
     @info "Building a two-body system..."
     eqs = [connect(T_sensor1.port, mass1.port, th_conductor.port_a)
@@ -49,8 +49,8 @@ using OrdinaryDiffEq: ReturnCode.Success
     m1, m2 = sol.u[end]
     @test m1≈m2 atol=1e-1
     mass_T = reduce(hcat, sol.u)
-    @test sol[T_sensor1.T] == mass_T[1, :]
-    @test sol[T_sensor2.T] == mass_T[2, :]
+    @test sol[T_sensor1.T.u] == mass_T[1, :]
+    @test sol[T_sensor2.T.u] == mass_T[2, :]
 end
 
 # Test HeatFlowSensor, FixedHeatFlow, ThermalResistor, ThermalConductor
@@ -81,7 +81,7 @@ end
 
     @test SciMLBase.successful_retcode(sol)
     @test sol[th_conductor.dT] .* G == sol[th_conductor.Q_flow]
-    @test sol[th_conductor.Q_flow] ≈ sol[hf_sensor1.Q_flow] + sol[flow_src.port.Q_flow]
+    @test sol[th_conductor.Q_flow] ≈ sol[hf_sensor1.Q_flow.u] + sol[flow_src.port.Q_flow]
 
     @test sol[mass1.T] == sol[th_resistor.port_a.T]
     @test sol[th_resistor.dT] ./ R ≈ sol[th_resistor.Q_flow]


### PR DESCRIPTION
https://github.com/SciML/ModelingToolkitStandardLibrary.jl/issues/384
Using RealOutputs for thermal sensors.  Note that any existing usage of temperature sensors will need to be updated (i.e. referencing of sensor output goes from T -> T.u).  Connections to sensor output are now possible.   Thermal sensors are now following the same style as those in Rotational with sensor output on connectors.  

Removing usage of OrdinaryDiffEqDefaults in tests

## Checklist

- [ x] Appropriate tests were added
- [x ] Any code changes were done in a way that does not break public API
- [x ] All documentation related to code changes were updated
- [ x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x ] Any new documentation only uses public API
  
## Additional context
No new tests were added but existing tests in Thermal package all pass.  Note that usage of OrdinaryDiffEqDefaults was removed from a few tests.  This package was not included when I instantiated and doesn't seem necessary.  Please check if this change is also OK?

Add any other context about the problem here.
