### PR TITLE
Fix initialization for TranslationalPosition and add more tests

### DIFF
--- a/docs/src/connectors/connections.md
+++ b/docs/src/connectors/connections.md
@@ -172,7 +172,7 @@ Now, let's consider the position-based approach.  We can build the same model wi
 const TP = ModelingToolkitStandardLibrary.Mechanical.TranslationalPosition
 
 systems = @named begin
-    damping = TP.Damper(d = 1, va = 1, vb = 0.0)
+    damping = TP.Damper(d = 1)
     body = TP.Mass(m = 1, v = 1)
     ground = TP.Fixed(s_0 = 0)
 end
@@ -191,7 +191,7 @@ nothing # hide
 As can be seen, we get exactly the same result.  The only difference here is that we are solving an extra equation, which allows us to plot the body position as well.
 
 ```@example connections
-prob = ODEProblem(sys, [], (0, 10.0), [])
+prob = ODEProblem(sys, [], (0, 10.0), [], fully_determined=true)
 sol_p = solve(prob)
 
 p1 = plot(sol_p, idxs = [body.v])
@@ -226,21 +226,21 @@ In this problem, we have a mass, spring, and damper which are connected to a fix
 
 #### Damper
 
-The damper will connect the flange/flange 1 (`flange_a`) to the mass, and flange/flange 2 (`flange_b`) to the fixed point.  For both position- and velocity-based domains, we set the damping constant `d=1` and `va=1` and leave the default for `v_b_0` at 0.  For the position domain, we also need to set the initial positions for `flange_a` and `flange_b`.
+The damper will connect the flange/flange 1 (`flange_a`) to the mass, and flange/flange 2 (`flange_b`) to the fixed point.  For both position- and velocity-based domains, we set the damping constant `d=1` and `va=1` and leave the default for `v_b_0` at 0.
 
 ```@example connections
 @named dv = TV.Damper(d = 1)
-@named dp = TP.Damper(d = 1, va = 1, vb = 0.0, flange_a__s = 3, flange_b__s = 1)
+@named dp = TP.Damper(d = 1)
 nothing # hide
 ```
 
 #### Spring
 
-The spring will connect the flange/flange 1 (`flange_a`) to the mass, and flange/flange 2 (`flange_b`) to the fixed point.  For both position- and velocity-based domains, we set the spring constant `k=1`.  The velocity domain then requires the initial velocity `va` and initial spring stretch `delta_s`.  The position domain instead needs the initial positions for `flange_a` and `flange_b` and the natural spring length `l`.
+The spring will connect the flange/flange 1 (`flange_a`) to the mass, and flange/flange 2 (`flange_b`) to the fixed point.  For both position- and velocity-based domains, we set the spring constant `k=1`.  The velocity domain then requires the initial velocity `va` and initial spring stretch `delta_s`. The position domain instead needs the natural spring length `l`.
 
 ```@example connections
 @named sv = TV.Spring(k = 1)
-@named sp = TP.Spring(k = 1, flange_a__s = 3, flange_b__s = 1, l = 1)
+@named sp = TP.Spring(k = 1, l = 1)
 nothing # hide
 ```
 
@@ -281,7 +281,7 @@ function simplify_and_solve(damping, spring, body, ground; initialization_eqs = 
 
     println.(full_equations(sys))
 
-    prob = ODEProblem(sys, [], (0, 10.0), []; initialization_eqs)
+    prob = ODEProblem(sys, [], (0, 10.0), []; initialization_eqs, fully_determined=true)
     sol = solve(prob; abstol = 1e-9, reltol = 1e-9)
 
     return sol

--- a/src/Mechanical/TranslationalPosition/components.jl
+++ b/src/Mechanical/TranslationalPosition/components.jl
@@ -16,7 +16,7 @@ Flange fixed in housing at a given position.
         s_0 = 0
     end
     @components begin
-        flange = Flange(; s = s_0)
+        flange = Flange()
     end
     @equations begin
         flange.s ~ s_0
@@ -53,7 +53,7 @@ Sliding mass with inertia
         f(t)
     end
     @components begin
-        flange = Flange(; s = s)
+        flange = Flange()
     end
     @equations begin
         flange.s ~ s
@@ -65,7 +65,7 @@ end
 
 const REL = Val(:relative)
 @component function Spring(::Val{:relative}; name, k, va = 0.0, vb = 0.0,
-        delta_s = 0, flange_a__s = 0, flange_b__s = 0)
+        delta_s = 0)
     pars = @parameters begin
         k = k
     end
@@ -87,13 +87,7 @@ const REL = Val(:relative)
            flange_b.f ~ -f]
 
     return compose(
-        ODESystem(eqs, t, vars, pars; name = name,
-            defaults = [
-                flange_a.s => flange_a__s,
-                flange_b.s => flange_b__s,
-                flange_a.f => +delta_s * k,
-                flange_b.f => -delta_s * k
-            ]),
+        ODESystem(eqs, t, vars, pars; name = name),
         flange_a,
         flange_b)
 end
@@ -101,7 +95,7 @@ end
 const ABS = Val(:absolute)
 
 """
-    Spring(; name, k, flange_a__s = 0, flange_b__s = 0, l=0)
+    Spring(; name, k, l=0)
 
 Linear 1D translational spring
 
@@ -109,34 +103,31 @@ Linear 1D translational spring
 
   - `k`: [N/m] Spring constant
   - `l`: Unstretched spring length
-  - `flange_a__s`: [m] Initial value of absolute position of flange_a
-  - `flange_b__s`: [m] Initial value of absolute position of flange_b
 
 # Connectors:
 
   - `flange_a: 1-dim. translational flange on one side of spring`
   - `flange_b: 1-dim. translational flange on opposite side of spring` #default function
 """
-function Spring(; name, k, flange_a__s = 0, flange_b__s = 0, l = 0)
-    Spring(ABS; name, k, flange_a__s, flange_b__s, l)
+function Spring(; name, k, l = 0)
+    Spring(ABS; name, k, l)
 end #default function
 
 @component function Spring(::Val{:absolute};
-        name, k, flange_a__s = 0,
-        flange_b__s = 0, l = 0)
+        name, k, l = 0)
     pars = @parameters begin
         k = k
         l = l
     end
     vars = @variables begin
-        f(t) = k * (flange_a__s - flange_b__s - l)
+        f(t)
     end
 
-    @named flange_a = Flange(; s = flange_a__s, f = k * (flange_a__s - flange_b__s - l))
-    @named flange_b = Flange(; s = flange_b__s, f = -k * (flange_a__s - flange_b__s - l))
+    @named flange_a = Flange()
+    @named flange_b = Flange()
 
     eqs = [
-           #    delta_s ~ flange_a.s - flange_b.s
+           #   delta_s ~ flange_a.s - flange_b.s
            f ~ k * (flange_a.s - flange_b.s - l) #delta_s
            flange_a.f ~ +f
            flange_b.f ~ -f]
@@ -166,12 +157,12 @@ Linear 1D translational damper
     @variables begin
         va(t)
         vb(t)
-        f(t) = +(va - vb) * d
+        f(t)
     end
 
     @components begin
-        flange_a = Flange(; s = 0.0, f = (va - vb) * d)
-        flange_b = Flange(; s = 0.0, f = -(va - vb) * d)
+        flange_a = Flange()
+        flange_b = Flange()
     end
 
     @equations begin


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

The initializations produced by the `TranslationalPosition` components are very overconstrained. I think that there were some initialization workarounds that were needed in the past, but on more modern MTK versions these should no longer be needed.

One  of the things that I removed is the  equations that were`flange.s` from higler level components shuch as the `Spring` and `Damper`. Is this breaking?
