### PR TITLE
Fix documentation issues from #399

### DIFF
--- a/src/Electrical/Analog/transistors.jl
+++ b/src/Electrical/Analog/transistors.jl
@@ -300,11 +300,11 @@ Early voltage effect.
 
             C_jE ~ if V_EB > phi_E - Z_E
                 ((C_jE0 * gamma_E * (1 - ((phi_E - Z_E) / phi_E))^(-gamma_E - 1)) / phi_E) *
-                V_BE -
+                V_EB -
                 ((C_jE0 * gamma_E * (1 - ((phi_E - Z_E) / phi_E))^(-gamma_E - 1)) / phi_E) *
                 (phi_E - Z_E) + (C_jE0) / (1 - (phi_E - Z_E) / phi_E)^gamma_E
             else
-                (C_jE0) / (1 - V_BE / phi_E)^gamma_E
+                (C_jE0) / (1 - V_EB / phi_E)^gamma_E
             end
         end
 

--- a/src/Electrical/Digital/components.jl
+++ b/src/Electrical/Digital/components.jl
@@ -1,3 +1,7 @@
+using ModelingToolkit: ODESystem, t_nounits as t
+using ..Electrical: DigitalPin, _not, _and, _or, _xor
+const System = ODESystem
+
 # Adders
 """
 ```julia

--- a/src/Electrical/Digital/gates.jl
+++ b/src/Electrical/Digital/gates.jl
@@ -1,3 +1,7 @@
+using ModelingToolkit: ODESystem, t_nounits as t
+using ..Electrical: DigitalPin, _not, _and, _or, _xor
+const System = ODESystem
+
 """
 ```julia
 Not(; name)

--- a/src/Electrical/Digital/sources.jl
+++ b/src/Electrical/Digital/sources.jl
@@ -1,3 +1,7 @@
+using ModelingToolkit: ODESystem, t_nounits as t
+using ..Electrical: DigitalPin
+const System = ODESystem
+
 """
 ```julia
 PulseDiff(; name, Val = 1, dt = 0.1)

--- a/src/Electrical/Electrical.jl
+++ b/src/Electrical/Electrical.jl
@@ -10,7 +10,7 @@ using ..Thermal: HeatPort
 using ..Mechanical.Rotational: Flange, Support
 using ..Blocks: RealInput, RealOutput
 
-export Pin, OnePort
+export Pin, OnePort, DigitalPin
 include("utils.jl")
 
 export Capacitor,
@@ -30,14 +30,6 @@ include("Analog/mosfets.jl")
 export NPN, PNP
 include("Analog/transistors.jl")
 
-# include("Digital/gates.jl")
-# include("Digital/sources.jl")
-
-# TODO:
-# - digital
-# - machines
-# - multi-phase
-
 export Logic
 include("Digital/logic.jl")
 
@@ -47,7 +39,22 @@ export StdLogicVector, StdULogicVector,
 include("Digital/logic_vectors.jl")
 
 export LogicTable,
-       AndTable, OrTable, NotTable, XorTable
+       AndTable, OrTable, NotTable, XorTable,
+       _not, _and, _or, _xor
 include("Digital/tables.jl")
+
+export Not, And, Nand, Or, Nor, Xor, Xnor
+include("Digital/gates.jl")
+
+export HalfAdder, FullAdder, MUX, DEMUX, Encoder, Decoder
+include("Digital/components.jl")
+
+export PulseDiff, Set, Reset, Pulse
+include("Digital/sources.jl")
+
+# TODO:
+# - digital
+# - machines
+# - multi-phase
 
 end

--- a/src/Mechanical/Translational/sensors.jl
+++ b/src/Mechanical/Translational/sensors.jl
@@ -5,8 +5,9 @@ Linear 1D force sensor, measures the force between two flanges.
 
 # Connectors:
 
-- `flange`: 1-dim. translational flange
-- `output`: real output
+- `flange_a`: 1-dim. translational flange ([`MechanicalPort`](@ref))
+- `flange_b`: 1-dim. translational flange ([`MechanicalPort`](@ref))
+- `output`: real output ([`RealOutput`](@ref))
 """
 @mtkmodel ForceSensor begin
     @components begin
@@ -33,8 +34,8 @@ Linear 1D position sensor.
 
 # Connectors:
 
-- `flange`: 1-dim. translational flange
-- `output`: real output
+- `flange`: 1-dim. translational flange ([`MechanicalPort`](@ref))
+- `output`: real output ([`RealOutput`](@ref))
 """
 @mtkmodel PositionSensor begin
     @components begin
@@ -64,8 +65,8 @@ Linear 1D acceleration sensor.
 
 # Connectors:
 
-- `flange`: 1-dim. translational flange
-- `output`: real output
+- `flange`: 1-dim. translational flange ([`MechanicalPort`](@ref))
+- `output`: real output ([`RealOutput`](@ref))
 """
 @mtkmodel AccelerationSensor begin
     @components begin


### PR DESCRIPTION
## Summary
This PR addresses multiple documentation issues reported in #399:

- ✅ Missing docstrings for Digital Gates components
- ✅ Incorrect variable usage in PNP transistor model  
- ✅ Missing cross-references in sensor documentation

## Changes Made

### Digital Module Fixes
- Enabled previously commented-out Digital Gates module (`gates.jl`)
- Enabled Digital Components module (`components.jl`) 
- Enabled Digital Sources module (`sources.jl`)
- Added proper exports for all Digital components (Not, And, Nand, Or, Nor, Xor, Xnor, HalfAdder, FullAdder, MUX, DEMUX, Encoder, Decoder, PulseDiff, Set, Reset, Pulse)
- Exported DigitalPin connector and logic functions (_not, _and, _or, _xor)
- Reorganized module includes to ensure logic functions are loaded before components that use them

### PNP Transistor Fix
- Fixed incorrect variable reference in PNP transistor model where `V_BE` was used instead of `V_EB` in the advanced continuation equations (lines 303 and 307)

### Documentation Cross-References
- Added cross-references to `MechanicalPort` and `RealOutput` in:
  - AccelerationSensor
  - PositionSensor  
  - ForceSensor

## Test plan
- [x] Package precompiles successfully
- [x] Digital components are properly exported and accessible
- [x] No new test failures introduced

Fixes #399

🤖 Generated with [Claude Code](https://claude.ai/code)