### PR TITLE
docs: import SciCompDSL and use symbolic map in ODEProblem

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -8,6 +8,7 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 ModelingToolkitStandardLibrary = "16a59e39-deab-5bd0-87e4-056b12336739"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+SciCompDSL = "91a8cdf1-4ca6-467b-a780-87fda3fff15e"
 
 [compat]
 ControlSystemsBase = "1.1"
@@ -18,3 +19,4 @@ IfElse = "0.1"
 ModelingToolkit = "11"
 OrdinaryDiffEq = "6, 7"
 Plots = "1.36"
+SciCompDSL = "1"

--- a/docs/src/connectors/connections.md
+++ b/docs/src/connectors/connections.md
@@ -113,7 +113,7 @@ nothing # hide
 The solution shows what we would expect, a non-linear dissipation of voltage and related decrease in current flow…
 
 ```@example connections
-prob = ODEProblem(sys, [1.0], (0, 10.0))
+prob = ODEProblem(sys, [capacitor.v => 1.0], (0, 10.0))
 sol = solve(prob)
 
 p1 = plot(sol, idxs = [capacitor.v])

--- a/docs/src/connectors/sign_convention.md
+++ b/docs/src/connectors/sign_convention.md
@@ -61,6 +61,7 @@ The flow variable (i.e. force) input component for the `Mechanical` domain is
 using ModelingToolkit
 using ModelingToolkitStandardLibrary.Mechanical.Translational
 using ModelingToolkit: t_nounits as t
+using SciCompDSL
 
 @mtkmodel ConstantForce begin
     @parameters begin

--- a/docs/src/tutorials/MOSFET_calibration.md
+++ b/docs/src/tutorials/MOSFET_calibration.md
@@ -10,6 +10,7 @@ using ModelingToolkitStandardLibrary.Electrical
 using ModelingToolkitStandardLibrary.Blocks: Constant
 using OrdinaryDiffEq
 using Plots
+using SciCompDSL
 ```
 
 Here we just connect the source pin to ground, the drain pin to a voltage source named `Vcc`, and the gate pin to a voltage source named `Vb`.

--- a/docs/src/tutorials/custom_component.md
+++ b/docs/src/tutorials/custom_component.md
@@ -12,6 +12,7 @@ using ModelingToolkit: t_nounits as t
 using ModelingToolkitStandardLibrary.Electrical
 using OrdinaryDiffEq
 using Plots
+using SciCompDSL
 ```
 
 ## Custom Component

--- a/docs/src/tutorials/dc_motor_pi.md
+++ b/docs/src/tutorials/dc_motor_pi.md
@@ -20,6 +20,7 @@ using ModelingToolkitStandardLibrary.Mechanical.Rotational
 using ModelingToolkitStandardLibrary.Blocks
 using OrdinaryDiffEq
 using Plots
+using SciCompDSL
 ```
 
 The actual model can now be composed.

--- a/docs/src/tutorials/input_component.md
+++ b/docs/src/tutorials/input_component.md
@@ -32,6 +32,7 @@ using DataInterpolations
 using OrdinaryDiffEq
 using DataFrames
 using Plots
+using SciCompDSL
 
 function MassSpringDamper(; name)
     @named input = RealInput()

--- a/docs/src/tutorials/rc_circuit.md
+++ b/docs/src/tutorials/rc_circuit.md
@@ -11,6 +11,7 @@ using ModelingToolkit, OrdinaryDiffEq, Plots
 using ModelingToolkitStandardLibrary.Electrical
 using ModelingToolkitStandardLibrary.Blocks: Constant
 using ModelingToolkit: t_nounits as t
+using SciCompDSL
 
 @mtkmodel RC begin
     @parameters begin

--- a/docs/src/tutorials/thermal_model.md
+++ b/docs/src/tutorials/thermal_model.md
@@ -9,6 +9,7 @@ from dividing the total initial energy in the system by the sum of the heat capa
 ```@example
 using ModelingToolkitStandardLibrary.Thermal, ModelingToolkit, OrdinaryDiffEq, Plots
 using ModelingToolkit: t_nounits as t
+using SciCompDSL
 
 @mtkmodel HeatConductionModel begin
     @parameters begin


### PR DESCRIPTION
## Summary

The Documentation job on `main` is failing with two distinct errors:

1. `UndefVarError: @mtkmodel not defined in Main.__atexample__named__sign_convention` — and the same in every tutorial that defines an \`@mtkmodel\` block. ModelingToolkit 11 no longer re-exports SciCompDSL, so `@mtkmodel` (and similar macros) are not in scope after \`using ModelingToolkit\` alone. The new test files added in #445 already do \`using SciCompDSL\`; the docs were missed. Add \`using SciCompDSL\` to each affected \`@example\` block, and \`SciCompDSL\` to \`docs/Project.toml\`.

2. `ArgumentError: The operating_point passed to the problem constructor must be a symbolic map.` from \`docs/src/connectors/connections.md:115\`'s \`ODEProblem(sys, [1.0], (0, 10.0))\`. With SciMLBase v3 / MTK 11, the second positional argument must be a symbolic map, not a bare \`Vector{Float64}\`. Replace with \`[capacitor.v => 1.0]\`.

## Changes

- \`docs/Project.toml\`: add \`SciCompDSL = \"1\"\` dep + compat.
- \`docs/src/connectors/sign_convention.md\`, \`docs/src/connectors/connections.md\`, \`docs/src/tutorials/{rc_circuit,custom_component,dc_motor_pi,input_component,thermal_model,MOSFET_calibration}.md\`: \`using SciCompDSL\` in each \`@example\` block that uses \`@mtkmodel\` / \`@mtkcompile\`.
- \`docs/src/connectors/connections.md\`: \`ODEProblem(sys, [1.0], …)\` → \`ODEProblem(sys, [capacitor.v => 1.0], …)\`.

## Test plan

- [ ] Documentation job builds without `UndefVarError: @mtkmodel`.
- [ ] `connections.md` electrical example resolves the `operating_point` error.