### PR TITLE
docs: namespace MTK analysis-point helpers and import ImplicitEuler

### DIFF
--- a/docs/src/tutorials/dc_motor_pi.md
+++ b/docs/src/tutorials/dc_motor_pi.md
@@ -117,12 +117,12 @@ T(s) &= \dfrac{P(s)C(s)}{I + P(s)C(s)}
 using ControlSystemsBase
 # Get sensitivity function
 matrices_S,
-simplified_sys_S = Blocks.get_sensitivity(
+simplified_sys_S = ModelingToolkit.get_sensitivity(
     model, :y, op = Dict(unknowns(sys) .=> 0.0))
 So = ss(matrices_S...) |> minreal # The output-sensitivity function as a StateSpace system
 # Get complementary sensitivity function
 matrices_T,
-simplified_sys_T = Blocks.get_comp_sensitivity(
+simplified_sys_T = ModelingToolkit.get_comp_sensitivity(
     model, :y, op = Dict(unknowns(sys) .=> 0.0))
 To = ss(matrices_T...)# The output complementary sensitivity function as a StateSpace system
 bodeplot([So, To], label = ["S" "T"], plot_title = "Sensitivity functions",
@@ -133,7 +133,7 @@ Similarly, we may compute the loop-transfer function and plot its Nyquist curve
 
 ```@example dc_motor_pi
 matrices_L,
-simplified_sys_L = Blocks.get_looptransfer(
+simplified_sys_L = ModelingToolkit.get_looptransfer(
     model, :y, op = Dict(unknowns(sys) .=> 0.0))
 L = -ss(matrices_L...) # The loop-transfer function as a StateSpace system. The negative sign is to negate the built-in negative feedback
 Ms, ωMs = hinfnorm(So) # Compute the peak of the sensitivity function to draw a circle in the Nyquist plot

--- a/docs/src/tutorials/input_component.md
+++ b/docs/src/tutorials/input_component.md
@@ -187,6 +187,7 @@ using ModelingToolkit
 using ModelingToolkit: t_nounits as t, D_nounits as D
 using ModelingToolkitStandardLibrary.Blocks
 using OrdinaryDiffEq
+using OrdinaryDiffEqSDIRK: ImplicitEuler
 
 const rdata = Ref{Vector{Float64}}()
 


### PR DESCRIPTION
## Summary

Follow-up to #448. Unblocking the \`connections.md\` operating_point error surfaced two more independent docs build failures on \`main\`:

- **\`docs/src/tutorials/dc_motor_pi.md\`** uses \`Blocks.get_sensitivity\`, \`Blocks.get_comp_sensitivity\`, and \`Blocks.get_looptransfer\`. Those helpers were moved out of \`ModelingToolkitStandardLibrary.Blocks\` into \`ModelingToolkit\` proper. Update the calls to \`ModelingToolkit.get_sensitivity\` / \`ModelingToolkit.get_comp_sensitivity\` / \`ModelingToolkit.get_looptransfer\`.

- **\`docs/src/tutorials/input_component.md\`** \`custom_component_external_data\` example calls \`solve(prob, ImplicitEuler())\`, but \`OrdinaryDiffEq\` v7 no longer re-exports \`ImplicitEuler\` (same narrowed-export pattern as the other solvers in #445). Add \`using OrdinaryDiffEqSDIRK: ImplicitEuler\`.

## Remaining docs failures (not in this PR)

- \`docs/src/tutorials/custom_component.md\` \`@mtkmodel ChaoticAttractor\` raises \`UndefVarError: NonlinearResistor not defined in Main.__atexample__named__components\` even though \`NonlinearResistor\` is defined by an earlier \`@example components\` block. The error originates inside the SciCompDSL \`@mtkmodel\` expansion at \`model_parsing.jl:157\`. Looks like a name-resolution issue when the generated constructor body runs inside a Documenter \`@example\` module — likely upstream SciCompDSL.
- \`MethodError: fntype_X_Y(::Type{Real})\` from SymbolicUtils when the parametrized_interpolation example computes \`promote_symtype\`. The only existing method is \`fntype_X_Y(::Type{<:SymbolicUtils.FnType{X, Y}})\`. Looks like a SymbolicUtils dispatch gap.

## Test plan

- [ ] Documentation build clears the \`UndefVarError: get_sensitivity\` and \`get_looptransfer\` failures.
- [ ] \`ImplicitEuler\` resolves in the \`custom_component_external_data\` block.