### PR TITLE
Feat/electrical machines pmsm

### DIFF
--- a/docs/src/API/electrical.md
+++ b/docs/src/API/electrical.md
@@ -88,3 +88,13 @@ Set
 Reset
 Pulse
 ```
+
+## Machines
+
+```@meta
+CurrentModule = ModelingToolkitStandardLibrary.Electrical.Machines
+```
+
+```@docs
+PMSM
+```

--- a/src/Electrical/Electrical.jl
+++ b/src/Electrical/Electrical.jl
@@ -35,7 +35,6 @@ include("Analog/transistors.jl")
 
 # TODO:
 # - digital
-# - machines
 # - multi-phase
 
 export Logic
@@ -49,5 +48,8 @@ include("Digital/logic_vectors.jl")
 export LogicTable,
     AndTable, OrTable, NotTable, XorTable
 include("Digital/tables.jl")
+
+# Machines (Electrical.Machines submodule)
+include("Machines/Machines.jl")
 
 end

--- a/src/Electrical/Machines/Machines.jl
+++ b/src/Electrical/Machines/Machines.jl
@@ -1,0 +1,11 @@
+module Machines
+
+using ModelingToolkitBase, Symbolics
+using ModelingToolkitBase: t_nounits as t, D_nounits as D
+using ...Electrical: Pin
+using ...Mechanical.Rotational: Flange, Support
+
+export PMSM
+include("pmsm.jl")
+
+end #module

--- a/src/Electrical/Machines/pmsm.jl
+++ b/src/Electrical/Machines/pmsm.jl
@@ -1,0 +1,143 @@
+"""
+    PMSM(; name, R = 0.5, Ls = 1e-3, lambda = 0.01, p = 4, Jr = 1e-4, Dr = 1e-4)
+
+Surface-mounted permanent-magnet synchronous machine (sinusoidal back-EMF,
+isolated-wye stator, non-salient so `Ld = Lq = Ls`).
+
+The three stator terminals are individual electrical [`Pin`](@ref)s; the star
+point is internal and isolated (`i_a + i_b + i_c = 0`). The shaft is a
+`Mechanical.Rotational.Flange` referenced to the housing
+`Mechanical.Rotational.Support`, so the machine composes with the standard
+`Mechanical.Rotational` inertia/load/sensor components like any other
+electromechanical element (it is the magnet-excited, three-phase
+generalisation of the `EMF` component).
+
+Per-phase stator equation (`x ∈ {a, b, c}`, electrical angle
+`θ = p·φ`, magnet flux linkage `ψ_x = lambda·cos(θ - kₓ·2π/3)`):
+
+```
+pin_x.v - v_star = R·i_x + Ls·d(i_x)/dt + d(ψ_x)/dt
+```
+
+Electromagnetic torque is taken in the flux form (no division by speed, so it
+is well posed through standstill):
+
+```
+τ_e = -p·lambda·Σ i_x·sin(θ - kₓ·2π/3)
+```
+
+# States
+
+  - `phi(t)`: [`rad`] Rotor mechanical angle relative to the support
+  - `w(t)`: [`rad/s`] Rotor mechanical angular velocity
+  - `i_a(t)`, `i_b(t)`, `i_c(t)`: [`A`] Stator phase currents
+  - `tau_e(t)`: [`N·m`] Electromagnetic (air-gap) torque
+  - `e_a(t)`, `e_b(t)`, `e_c(t)`: [`V`] Permanent-magnet back-EMF
+  - `psi_a(t)`, `psi_b(t)`, `psi_c(t)`: [`Wb`] Stator flux linkage
+
+# Connectors
+
+  - `pin_a` Stator phase-A terminal ([`Pin`](@ref))
+  - `pin_b` Stator phase-B terminal ([`Pin`](@ref))
+  - `pin_c` Stator phase-C terminal ([`Pin`](@ref))
+  - `flange` Rotor shaft (`Mechanical.Rotational.Flange`)
+  - `support` Machine housing (`Mechanical.Rotational.Support`)
+
+# Parameters
+
+  - `R`: [`Ω`] Stator resistance per phase
+  - `Ls`: [`H`] Synchronous (per-phase) inductance, `Ld = Lq = Ls`
+  - `lambda`: [`Wb`] Permanent-magnet flux linkage (back-EMF constant)
+  - `p`: Number of pole pairs
+  - `Jr`: [`kg·m²`] Rotor moment of inertia
+  - `Dr`: [`N·m·s`] Rotor viscous friction coefficient
+"""
+@component function PMSM(;
+        name, R = 0.5, Ls = 1.0e-3, lambda = 0.01,
+        p = 4, Jr = 1.0e-4, Dr = 1.0e-4
+    )
+    pars = @parameters begin
+        R = R, [description = "Stator resistance per phase"]
+        Ls = Ls, [description = "Synchronous (per-phase) inductance"]
+        lambda = lambda, [description = "Permanent-magnet flux linkage"]
+        p = p, [description = "Number of pole pairs"]
+        Jr = Jr, [description = "Rotor moment of inertia"]
+        Dr = Dr, [description = "Rotor viscous friction coefficient"]
+    end
+
+    systems = @named begin
+        pin_a = Pin()
+        pin_b = Pin()
+        pin_c = Pin()
+        flange = Flange()
+        support = Support()
+    end
+
+    vars = @variables begin
+        phi(t), [guess = 0.0, description = "Rotor mechanical angle"]
+        w(t), [guess = 0.0, description = "Rotor mechanical speed"]
+        i_a(t), [guess = 0.0, description = "Phase-A current"]
+        i_b(t), [guess = 0.0, description = "Phase-B current"]
+        i_c(t), [guess = 0.0, description = "Phase-C current"]
+        v_star(t), [guess = 0.0, description = "Star-point potential"]
+        tau_e(t), [guess = 0.0, description = "Electromagnetic torque"]
+        e_a(t), [guess = 0.0, description = "Phase-A back-EMF"]
+        e_b(t), [guess = 0.0, description = "Phase-B back-EMF"]
+        e_c(t), [guess = 0.0, description = "Phase-C back-EMF"]
+        psi_a(t), [guess = 0.0, description = "Phase-A stator flux linkage"]
+        psi_b(t), [guess = 0.0, description = "Phase-B stator flux linkage"]
+        psi_c(t), [guess = 0.0, description = "Phase-C stator flux linkage"]
+    end
+
+    g = 2 * pi / 3                       # 120° phase separation
+    th = p * phi                         # electrical angle
+
+    # Built as grouped sub-vectors so the explanatory comments stay on
+    # plain statement lines (comments inside an array literal do not
+    # survive autoformatting cleanly).
+
+    # mechanical: shaft rigid to rotor, angle/speed referenced to support
+    mech = [
+        phi ~ flange.phi - support.phi,
+        D(phi) ~ w,
+    ]
+
+    # stator phase currents flow in through the pins
+    terminals = [
+        i_a ~ pin_a.i,
+        i_b ~ pin_b.i,
+        i_c ~ pin_c.i,
+    ]
+
+    # per-phase stator voltage (phase-to-star); isolated wye closes v_star
+    stator = [
+        pin_a.v - v_star ~ R * i_a + Ls * D(i_a) + e_a,
+        pin_b.v - v_star ~ R * i_b + Ls * D(i_b) + e_b,
+        pin_c.v - v_star ~ R * i_c + Ls * D(i_c) + e_c,
+        0 ~ i_a + i_b + i_c,
+    ]
+
+    # magnetic-domain observables: PM back-EMF e_x = d(ψ_pm,x)/dt and
+    # total stator flux linkage ψ_x = Ls·i_x + lambda·cos(th - kₓ·g)
+    magnetic = [
+        e_a ~ -lambda * p * w * sin(th),
+        e_b ~ -lambda * p * w * sin(th - g),
+        e_c ~ -lambda * p * w * sin(th + g),
+        psi_a ~ Ls * i_a + lambda * cos(th),
+        psi_b ~ Ls * i_b + lambda * cos(th - g),
+        psi_c ~ Ls * i_c + lambda * cos(th + g),
+    ]
+
+    # electromagnetic torque (flux form, no 1/w), rotor free body, and
+    # housing reaction (massless stator) keeping Σ external τ = Jr·dw/dt
+    dynamics = [
+        tau_e ~ -p * lambda *
+            (i_a * sin(th) + i_b * sin(th - g) + i_c * sin(th + g)),
+        Jr * D(w) ~ tau_e - Dr * w + flange.tau,
+        support.tau ~ tau_e - Dr * w,
+    ]
+
+    equations = [mech; terminals; stator; magnetic; dynamics]
+
+    return System(equations, t, vars, pars; name, systems)
+end

--- a/test/Electrical/machines.jl
+++ b/test/Electrical/machines.jl
@@ -1,0 +1,116 @@
+using ModelingToolkitStandardLibrary.Electrical
+using ModelingToolkitStandardLibrary.Electrical.Machines
+using SciCompDSL
+using ModelingToolkitStandardLibrary.Mechanical.Rotational
+using ModelingToolkitStandardLibrary.Blocks
+using ModelingToolkit, OrdinaryDiffEq, Test
+using ModelingToolkit: t_nounits as t, D_nounits as D
+using OrdinaryDiffEq: ReturnCode.Success
+using OrdinaryDiffEqRosenbrock: Rodas4
+
+# local mean (Statistics is not a test dependency of this package)
+avg(x) = sum(x) / length(x)
+
+# Machine under test (small surface PMSM)
+R = 0.5
+Ls = 1.0e-3
+lambda = 0.01
+pp = 4
+Jr = 1.0e-4
+Dr = 1.0e-4
+
+@testset "PMSM: back-EMF constant" begin
+    # Spin the shaft at a fixed speed; the PM back-EMF is then a balanced
+    # 3-phase set of amplitude lambda*p*w0 (independent of stator load,
+    # since e_x is an explicit function of speed and rotor angle).
+    w0 = 100.0
+    A = lambda * pp * w0                      # expected back-EMF amplitude
+
+    @mtkmodel BackEMF begin
+        @components begin
+            machine = PMSM(
+                R = R, Ls = Ls, lambda = lambda, p = pp,
+                Jr = Jr, Dr = Dr
+            )
+            speed = Speed(exact = true)
+            wref = Constant(k = w0)
+            fixed = Fixed()
+            ra = Resistor(R = 10.0)
+            rb = Resistor(R = 10.0)
+            rc = Resistor(R = 10.0)
+            ground = Ground()
+        end
+        @equations begin
+            connect(wref.output, speed.w_ref)
+            connect(speed.flange, machine.flange)
+            connect(machine.support, fixed.flange)
+            connect(machine.pin_a, ra.p)
+            connect(machine.pin_b, rb.p)
+            connect(machine.pin_c, rc.p)
+            connect(ra.n, rb.n, rc.n, ground.g)
+        end
+    end
+
+    @mtkcompile sys = BackEMF()
+    prob = ODEProblem(sys, unknowns(sys) .=> 0.0, (0.0, 0.1))
+    sol = solve(prob, Rodas4())
+    @test sol.retcode == Success
+
+    # steady window (speed is imposed → reached immediately)
+    mask = sol.t .> 0.03
+    ea = sol[sys.machine.e_a][mask]
+    eb = sol[sys.machine.e_b][mask]
+    ec = sol[sys.machine.e_c][mask]
+
+    # amplitude over a window spanning several electrical periods
+    @test maximum(ea) ≈ A rtol = 2.0e-2
+    @test minimum(ea) ≈ -A rtol = 2.0e-2
+    # balanced 3-phase invariant (sampling-robust): Σ e² = 3/2 · A²
+    @test avg(ea .^ 2 .+ eb .^ 2 .+ ec .^ 2) ≈ 1.5 * A^2 rtol = 2.0e-2
+    # isolated wye: phase currents sum to zero
+    sumi = sol[sys.machine.i_a] .+ sol[sys.machine.i_b] .+ sol[sys.machine.i_c]
+    @test maximum(abs.(sumi)) < 1.0e-8
+end
+
+@testset "PMSM: locked-rotor q-axis torque" begin
+    # Rotor locked at theta_e = 0; inject a balanced q-axis current set
+    # (0, -Iq, +Iq). Closed form magnitude: |tau_e| = sqrt(3)·p·lambda·Iq.
+    Iq = 5.0
+
+    # Single line-to-line current source (pin_b -> pin_c) gives
+    # i_b = +Iq, i_c = -Iq, i_a = 0 -- consistent with the isolated wye
+    # (3 sources would make Σi = 0 redundant -> structurally singular).
+    @mtkmodel LockedRotor begin
+        @components begin
+            machine = PMSM(
+                R = R, Ls = Ls, lambda = lambda, p = pp,
+                Jr = Jr, Dr = Dr
+            )
+            fixed_shaft = Fixed()
+            fixed_house = Fixed()
+            isrc = Current()
+            iq = Constant(k = Iq)
+            ground = Ground()
+        end
+        @equations begin
+            connect(machine.flange, fixed_shaft.flange)
+            connect(machine.support, fixed_house.flange)
+            connect(iq.output, isrc.I)
+            connect(isrc.p, machine.pin_b)
+            connect(isrc.n, machine.pin_c)
+            connect(machine.pin_a, ground.g)
+        end
+    end
+
+    @mtkcompile sys = LockedRotor()
+    prob = ODEProblem(sys, unknowns(sys) .=> 0.0, (0.0, 0.05))
+    sol = solve(prob, Rodas4())
+    @test sol.retcode == Success
+
+    @test abs(sol[sys.machine.tau_e][end]) ≈ sqrt(3) * pp * lambda * Iq rtol = 1.0e-3
+    # isolated wye: phase currents sum to zero
+    @test abs(
+        sol[sys.machine.i_a][end] + sol[sys.machine.i_b][end] +
+            sol[sys.machine.i_c][end]
+    ) < 1.0e-8
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,9 @@ const GROUP = get(ENV, "GROUP", "All")
             @safetestset "Digital Circuits" begin
                 include("Electrical/digital.jl")
             end
+            @safetestset "Electrical Machines" begin
+                include("Electrical/machines.jl")
+            end
             @safetestset "Chua Circuit Demo" begin
                 include("chua_circuit.jl")
             end


### PR DESCRIPTION

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

I was looking for a combined electrical+magnetic+mechanical sim, and this solved my need. But I'm not sure if it's of interest to folks.

Closes the `# - machines` TODO in Electrical.jl with a first permanent-magnet synchronous machine, built entirely from existing connectors (no new domain) -- the magnet-excited, three-phase generalisation of EMF.

Component (src/Electrical/Machines/{Machines.jl,pmsm.jl}):
- Surface PMSM (Ld = Lq = Ls), sinusoidal back-EMF, isolated-wye stator.
- Three electrical Pins + Mechanical.Rotational Flange/Support, so the mechanical load composes from stock Inertia/Damper/Torque/sensors.
- Electromagnetic torque in flux form (no 1/omega -> well posed through standstill); free body verified (sum of external torque = Jr*dw/dt).
- Exposes electrical (i_abc), magnetic (psi_abc, e_abc) and mechanical (w, tau_e) observables.
- Submodule wired into Electrical.jl mirroring Magnetic/FluxTubes.
- Formatted with SciMLStyle (idempotent); equations built as grouped sub-vectors so comments stay formatter-stable.

Tests (test/Electrical/machines.jl, wired into runtests.jl):
- Open-circuit back-EMF amplitude = lambda*p*w and the balanced-set invariant sum(e^2) = 3/2*A^2 (sampling-robust).
- Locked-rotor q-axis torque |tau| = sqrt(3)*p*lambda*Iq via a single line-to-line current source. Both testsets pass.

Docs: docs/src/API/electrical.md gains a Machines section autodoc-ing the public PMSM (mirrors how FluxTubes is documented in magnetic.md).