### PR TITLE
fix: drop stale _clamp import (un-break Blocks/math tests)

### DIFF
--- a/test/Blocks/math.jl
+++ b/test/Blocks/math.jl
@@ -1,7 +1,7 @@
 using ModelingToolkitStandardLibrary.Blocks
 using SciCompDSL
 using ModelingToolkit, OrdinaryDiffEq, Test
-using ModelingToolkitStandardLibrary.Blocks: _clamp, _dead_zone
+using ModelingToolkitStandardLibrary.Blocks: _dead_zone
 using ModelingToolkit: inputs, unbound_inputs, bound_inputs, t_nounits as t
 using OrdinaryDiffEq: ReturnCode.Success
 using OrdinaryDiffEqRosenbrock: Rodas4


### PR DESCRIPTION
Drops the stale `_clamp` import in `test/Blocks/math.jl` — `_clamp` was removed from the source (the `Limiter` component now uses the builtin `clamp`). The dead import errors `UndefVarError: _clamp` in the 2nd Core testset on every Julia/dep combination, redding master CI and blocking Downgrade re-enablement. `_clamp` is unused in the test; `_dead_zone` (still in source) is kept. Verified `_clamp` appears nowhere else in the repo.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)