### PR TITLE
ci: re-enable downgrade job (strict)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,7 +12,7 @@ on:
       - 'docs/**'
 jobs:
   test:
-    if: false
+    # Runs strict (allow_reresolve=false); expected RED until fntype regression (#458/#452) is resolved.
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       julia-version: "1.10"


### PR DESCRIPTION
Removes the `if: false` that was skipping the Downgrade workflow so the downgrade job runs again under the centralized `downgrade.yml@v1`.

Downgrade re-enabled strict (`allow_reresolve=false`); intentionally RED (natural failure, not disabled) pending the fntype regression (#458/#452). Auto-greens when that resolves.

No compat floors were lowered, `allow-reresolve` was not added, and `julia-version` stays "1.10".

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
