### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -16,19 +16,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        group:
-          - "Core"
-          - "QA"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      group: "${{ matrix.group }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,5 @@
+[Core]
+versions = ["1", "lts", "pre"]
+
+[QA]
+versions = ["1", "lts", "pre"]


### PR DESCRIPTION
## Summary

Converts the root **Tests.yml** test workflow into a thin caller of the canonical `SciML/.github` **grouped-tests.yml@v1** reusable workflow, with the package's group × version matrix declared once in a root **`test/test_groups.toml`**.

### Before
`Tests.yml` hand-maintained a matrix `{version: ["1","lts","pre"]} × {group: ["Core","QA"]}` (6 jobs) calling `tests.yml@v1` directly.

### After
- The matrix lives in `test/test_groups.toml`:
  ```toml
  [Core]
  versions = ["1", "lts", "pre"]

  [QA]
  versions = ["1", "lts", "pre"]
  ```
- `Tests.yml` becomes a thin caller:
  ```yaml
  jobs:
    tests:
      uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
      secrets: "inherit"
  ```

### Why no `with:` inputs
- `runtests.jl` already dispatches on the **standard `GROUP`** env var (Core/QA) — no `group-env-name` override needed, and **no `runtests.jl` change** is required.
- The old job used no `check-bounds`, `coverage`, `coverage-directories`, or `apt-packages` overrides, so the thin caller carries no `with:` block (all defaults match the old behavior).
- Linux-only: no `os` field (defaults to `ubuntu-latest`), matching the original.

### Preserved
- `name: "Tests"`, `on:` triggers, and `concurrency:` are kept **verbatim** so branch-protection status checks remain valid.
- All other workflow files are untouched.

## Matrix match

Ran `compute_affected_sublibraries.jl . --root-matrix` against the new `test/test_groups.toml`; it emits exactly the 6 cells the old workflow produced:

| group | versions |
|-------|----------|
| Core  | 1, lts, pre |
| QA    | 1, lts, pre |

All runners `ubuntu-latest`, `continue_on_error=false` (no non-fatal group like Downstream is in this root matrix — Downstream is a separate workflow). **6/6 exact match.**

## QA

Category A — Core/QA `GROUP` dispatch already existed in `runtests.jl`; static matrix-verification only (no local Aqua run needed). `test_groups.toml` parses as valid TOML and `Tests.yml` parses as valid YAML.

---

Ignore until reviewed by @ChrisRackauckas.