### PR TITLE
Use InitializationProblem() in the SISO tests

### DIFF
--- a/test/Blocks/utils.jl
+++ b/test/Blocks/utils.jl
@@ -34,9 +34,7 @@ end
     @named iosys = System(connect(c.output, so.input), t, systems = [so, c])
     sys = mtkcompile(iosys)
 
-    initsys = ModelingToolkit.generate_initializesystem(sys)
-    initsys = mtkcompile(initsys)
-    initprob = NonlinearProblem(initsys, merge(initial_conditions(sys), Dict([t => 0])))
+    initprob = ModelingToolkit.InitializationProblem(sys, 0.0)
     initsol = solve(initprob)
 
     @test initsol[sys.so.xd] == 1.0


### PR DESCRIPTION
This would otherwise throw errors from constructing NonlinearProblem directly, because a NonlinearProblem requires a square system.

Fixes this failure seen locally and in CI for https://github.com/SciML/SciMLBase.jl/pull/1386:
```julia
SISO Check: Error During Test at /home/runner/work/SciMLBase.jl/SciMLBase.jl/downstream/test/Blocks/utils.jl:30
  Got exception outside of a @test
  ExtraVariablesSystemException: The system is unbalanced. There are 4 highest order derivative variables and 3 equations.
  More variables than equations, here are the potential extra variable(s):
   so₊xdˍt(t)
  Note that the process of determining extra variables is a best-effort heuristic. The true extra variables are dependent on the model and may not be in this list.
  Stacktrace:
    [1] error_reporting(state::ModelingToolkitTearing.TearingState, bad_idxs::Vector{Int64}, n_highest_vars::Int64, iseqs::Bool, orig_inputs::Set{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}})
      @ StateSelection ~/.julia/packages/StateSelection/lR9ge/src/utils.jl:68
    [2] check_consistency(state::ModelingToolkitTearing.TearingState, orig_inputs::Set{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}; nothrow::Bool)
      @ StateSelection ~/.julia/packages/StateSelection/lR9ge/src/utils.jl:148
    [3] check_consistency
      @ ~/.julia/packages/StateSelection/lR9ge/src/utils.jl:123 [inlined]
    [4] _mtkcompile!(state::ModelingToolkitTearing.TearingState; check_consistency::Bool, fully_determined::Bool, dummy_derivative::Bool, discrete_inputs::OrderedCollections.OrderedSet{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, inputs::OrderedCollections.OrderedSet{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, outputs::OrderedCollections.OrderedSet{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, disturbance_inputs::OrderedCollections.OrderedSet{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, kwargs::@Kwargs{additional_passes::Tuple{}})
      @ ModelingToolkit ~/.julia/packages/ModelingToolkit/c0i0d/src/systems/systemstructure.jl:217
    [5] _mtkcompile!
      @ ~/.julia/packages/ModelingToolkit/c0i0d/src/systems/systemstructure.jl:192 [inlined]
    [6] mtkcompile!(state::ModelingToolkitTearing.TearingState; check_consistency::Bool, fully_determined::Bool, inputs::OrderedCollections.OrderedSet{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, outputs::OrderedCollections.OrderedSet{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, disturbance_inputs::OrderedCollections.OrderedSet{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, kwargs::@Kwargs{additional_passes::Tuple{}})
      @ ModelingToolkit ~/.julia/packages/ModelingToolkit/c0i0d/src/systems/systemstructure.jl:109
    [7] mtkcompile!
      @ ~/.julia/packages/ModelingToolkit/c0i0d/src/systems/systemstructure.jl:100 [inlined]
    [8] __mtkcompile(sys::ModelingToolkitBase.System; inputs::OrderedCollections.OrderedSet{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, outputs::OrderedCollections.OrderedSet{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, disturbance_inputs::OrderedCollections.OrderedSet{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, sort_eqs::Bool, kwargs::@Kwargs{additional_passes::Tuple{}})
      @ ModelingToolkit ~/.julia/packages/ModelingToolkit/c0i0d/src/systems/systems.jl:49
    [9] __mtkcompile
      @ ~/.julia/packages/ModelingToolkit/c0i0d/src/systems/systems.jl:23 [inlined]
   [10] _mtkcompile(sys::ModelingToolkitBase.System; kwargs::@Kwargs{inputs::OrderedCollections.OrderedSet{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, outputs::OrderedCollections.OrderedSet{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, disturbance_inputs::OrderedCollections.OrderedSet{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, additional_passes::Tuple{}})
      @ ModelingToolkitBase ~/.julia/packages/ModelingToolkitBase/PHXso/src/systems/systems.jl:149
   [11] _mtkcompile
      @ ~/.julia/packages/ModelingToolkitBase/PHXso/src/systems/systems.jl:122 [inlined]
   [12] mtkcompile(sys::ModelingToolkitBase.System; additional_passes::Tuple{}, inputs::Vector{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, outputs::Vector{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, disturbance_inputs::Vector{SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymbolicUtils.SymReal}}, split::Bool, kwargs::@Kwargs{})
      @ ModelingToolkitBase ~/.julia/packages/ModelingToolkitBase/PHXso/src/systems/systems.jl:95
   [13] mtkcompile(sys::ModelingToolkitBase.System)
      @ ModelingToolkitBase ~/.julia/packages/ModelingToolkitBase/PHXso/src/systems/systems.jl:84
   [14] macro expansion
      @ ~/work/SciMLBase.jl/SciMLBase.jl/downstream/test/Blocks/utils.jl:38 [inlined]
   [15] macro expansion
      @ /opt/hostedtoolcache/julia/1.10.11/x64/share/julia/stdlib/v1.10/Test/src/Test.jl:1582 [inlined]
   [16] top-level scope
      @ ~/work/SciMLBase.jl/SciMLBase.jl/downstream/test/Blocks/utils.jl:31
   [17] include(mod::Module, _path::String)
      @ Base ./Base.jl:495
   [18] include(x::String)
      @ Main.var"##Blocks: utils#226" ~/.julia/packages/SafeTestsets/raUNr/src/SafeTestsets.jl:28
   [19] macro expansion
      @ ~/work/SciMLBase.jl/SciMLBase.jl/downstream/test/runtests.jl:16 [inlined]
   [20] macro expansion
      @ /opt/hostedtoolcache/julia/1.10.11/x64/share/julia/stdlib/v1.10/Test/src/Test.jl:1582 [inlined]
   [21] macro expansion
      @ ~/work/SciMLBase.jl/SciMLBase.jl/downstream/test/runtests.jl:16 [inlined]
   [22] top-level scope
      @ ~/.julia/packages/SafeTestsets/raUNr/src/SafeTestsets.jl:30
   [23] eval(m::Module, e::Any)
      @ Core ./boot.jl:385
   [24] macro expansion
      @ ~/.julia/packages/SafeTestsets/raUNr/src/SafeTestsets.jl:28 [inlined]
   [25] macro expansion
      @ ~/work/SciMLBase.jl/SciMLBase.jl/downstream/test/runtests.jl:15 [inlined]
   [26] macro expansion
      @ /opt/hostedtoolcache/julia/1.10.11/x64/share/julia/stdlib/v1.10/Test/src/Test.jl:1582 [inlined]
   [27] macro expansion
      @ ~/work/SciMLBase.jl/SciMLBase.jl/downstream/test/runtests.jl:15 [inlined]
   [28] macro expansion
      @ ./timing.jl:279 [inlined]
   [29] top-level scope
      @ ~/work/SciMLBase.jl/SciMLBase.jl/downstream/test/runtests.jl:269
   [30] include(fname::String)
      @ Base.MainInclude ./client.jl:487
   [31] top-level scope
      @ none:6
```

Written with help from Claude :robot: There's a bunch of other failures too, but those seem a bit beyond me...

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API