### PR TITLE
Use InitializationProblem() in the SISO tests (rebase of #465)

### DIFF
--- a/test/utils.jl
+++ b/test/utils.jl
@@ -34,9 +34,7 @@ end
     @named iosys = System(connect(c.output, so.input), t, systems = [so, c])
     sys = mtkcompile(iosys)
 
-    initsys = ModelingToolkit.generate_initializesystem(sys)
-    initsys = mtkcompile(initsys)
-    initprob = NonlinearProblem(initsys, merge(initial_conditions(sys), Dict([t => 0])))
+    initprob = ModelingToolkit.InitializationProblem(sys, 0.0)
     initsol = solve(initprob)
 
     @test initsol[sys.so.xd] == 1.0


### PR DESCRIPTION
Rebased version of #465 by @JamesWrigley onto current `main`.

#465 became conflicting only because the test layout was restructured upstream (`test/Blocks/utils.jl` → `test/utils.jl` via #463/#464); there is no real content conflict. The change replaces the manual `generate_initializesystem` + `mtkcompile` + `NonlinearProblem` sequence with `ModelingToolkit.InitializationProblem(sys, 0.0)` in the SISO tests. Git followed the rename and applied it cleanly on top of release v2.29.1.

Supersedes #465 (which can be closed once this is reviewed). Original authorship preserved on the commit.

> Please ignore until reviewed by @ChrisRackauckas.
