### PR TITLE
Bump version to 2.29.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkitStandardLibrary"
 uuid = "16a59e39-deab-5bd0-87e4-056b12336739"
-version = "2.29.2"
+version = "2.29.3"
 authors = ["Chris Rackauckas and Julia Computing"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (2.29.2 -> 2.29.3) to release unreleased commits on `main` via JuliaRegistrator.