### PR TITLE
Release prep: bump to 2.29.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkitStandardLibrary"
 uuid = "16a59e39-deab-5bd0-87e4-056b12336739"
-version = "2.29.3"
+version = "2.29.4"
 authors = ["Chris Rackauckas and Julia Computing"]
 
 [deps]


### PR DESCRIPTION
Version-bump-only release PR. Adds direct SymbolicUtils dependency and repoints 'unwrap' import from Symbolics to SymbolicUtils (same function, removes an indirection layer).