### PR TITLE
test: use Base.ifelse in Chua circuit

### DIFF
--- a/test/chua_circuit.jl
+++ b/test/chua_circuit.jl
@@ -6,7 +6,6 @@ using ModelingToolkitStandardLibrary.Electrical: OnePort
 using OrdinaryDiffEq
 using OrdinaryDiffEq: ReturnCode.Success
 using OrdinaryDiffEqRosenbrock: Rodas4
-using IfElse: ifelse
 
 @testset "Chua Circuit" begin
     @component function NonlinearResistor(; name, Ga, Gb, Ve)


### PR DESCRIPTION
## Summary

Remove the stale `using IfElse: ifelse` from the Chua circuit test. The test now uses Julia's built-in `Base.ifelse`, matching the production-code migration in #473.

## Root cause

Commit `dca3a237b1cda8c6befdf5bd0ef53f4c03fbd9b9` removed IfElse.jl from the package dependencies and migrated production call sites, but missed `test/chua_circuit.jl`. The Core group has therefore failed at test loading since #473; the first bad release is v2.29.3 (v2.29.2 is the last release before the removal), and v2.29.4 remains affected.

This also breaks ModelingToolkit's downstream Core job on both master and unrelated PRs:

- [ModelingToolkit master](https://github.com/SciML/ModelingToolkit.jl/actions/runs/29186963983/job/86634738179)
- [ModelingToolkit PR #4730](https://github.com/SciML/ModelingToolkit.jl/actions/runs/29190999984/job/86645537310)
- [First failing Core job on #473](https://github.com/SciML/ModelingToolkitStandardLibrary.jl/actions/runs/28731796831/job/85201145714)

## Verification

Using Julia 1.12.6, ModelingToolkit `ee7dd34d8b7cfe8a085e0fa04cec28a607053f66`, and the reusable downstream workflow locally:

```text
# Unmodified v2.29.3
Core/analog.jl       | Pass 99  Total 99
Core/chua_circuit.jl | Error 1  Total 1
ArgumentError: Package IfElse not found in current path.

# Current main plus this patch
Core/analog.jl       | Pass 99  Total 99
Core/chua_circuit.jl | Pass 1   Total 1
```

`Runic v1.7.0 --check .` also completed successfully.

The full Core run continued past Chua and exposed three unrelated `isothermal_compressible.jl` `ExtraVariablesSystemException` errors. Those are outside this one-line test-import fix and are being routed to a separate clean-main reproduction/bisect; they were previously masked by the earlier Chua load error.

**Please ignore this PR until reviewed by @ChrisRackauckas.**
