### PR TITLE
Fix isothermal domain test connections

### DIFF
--- a/test/isothermal_compressible.jl
+++ b/test/isothermal_compressible.jl
@@ -1,4 +1,6 @@
 using ModelingToolkit, OrdinaryDiffEq, Test
+using ModelingToolkitBase: bindings, domain_connect, unknowns
+using SciMLBase: NoInit
 using SciCompDSL
 using OrdinaryDiffEqNonlinearSolve: NLNewton
 using ModelingToolkit: t_nounits as t, D_nounits as D
@@ -152,8 +154,7 @@ end
         end
 
         eqs = [
-            connect(fluid, src1.port)
-            connect(fluid, src2.port)
+            domain_connect(fluid, src1.port, src2.port)
             connect(src1.port, vol1.port)
             connect(src2.port, vol2.port)
             connect(vol1.flange, mass.flange, vol2.flange)
@@ -196,6 +197,8 @@ end
     # volume/mass should stop moving at opposite ends
     @test sol(0; idxs = sys.vol1.x) == 0.1
     @test sol(0; idxs = sys.vol2.x) == 0.1
+    @test sol[sys.src1.port.dm] ≈ -sol[sys.vol1.port.dm]
+    @test sol[sys.src2.port.dm] ≈ -sol[sys.vol2.port.dm]
 
     @test round(sol(1; idxs = sys.vol1.x); digits = 2) == 0.19
     @test round(sol(1; idxs = sys.vol2.x); digits = 2) == 0.01
@@ -293,7 +296,7 @@ end
 
             connect(src.port, valve.port_s)
             connect(snk.port, valve.port_r)
-            connect(fluid, src.port, snk.port)
+            domain_connect(fluid, src.port, snk.port)
             D(piston.mass.v) ~ ddx
         ]
 
@@ -307,7 +310,7 @@ end
     @mtkcompile initsys = ActuatorSystem(false)
 
     initprob = ODEProblem(initsys, [], (0, 0))
-    initsol = solve(initprob, Rodas5P())
+    initial_state = [v => initprob[v] for v in unknowns(initsys)]
 
     @mtkcompile sys = ActuatorSystem(true)
 
@@ -321,18 +324,19 @@ end
     defs[sys.input.buffer] = Parameter(0.5 * x, dt)
 
     # NOTE: bypassing initialization system: https://github.com/SciML/ModelingToolkit.jl/issues/3312
-    prob = ODEProblem(sys, unknowns(initsys) .=> initsol.u[end], (0, 0.1); build_initializeprob = false)
+    prob = ODEProblem(sys, initial_state, (0, 0.1); build_initializeprob = false)
 
     #TODO: Implement proper initialization system after issue is resolved
     #TODO: How to bring the body back and not have an overdetermined system?
 
     # check the fluid domain
-    @test Symbol(defs[sys.src.port.ρ]) == Symbol(sys.fluid.ρ)
-    @test Symbol(defs[sys.valve.port_s.ρ]) == Symbol(sys.fluid.ρ)
-    @test Symbol(defs[sys.valve.port_a.ρ]) == Symbol(sys.fluid.ρ)
-    @test Symbol(defs[sys.valve.port_b.ρ]) == Symbol(sys.fluid.ρ)
-    @test Symbol(defs[sys.valve.port_r.ρ]) == Symbol(sys.fluid.ρ)
-    @test Symbol(defs[sys.snk.port.ρ]) == Symbol(sys.fluid.ρ)
+    binds = bindings(sys)
+    @test Symbol(binds[sys.src.port.ρ]) == Symbol(sys.fluid.ρ)
+    @test Symbol(binds[sys.valve.port_s.ρ]) == Symbol(sys.fluid.ρ)
+    @test Symbol(binds[sys.valve.port_a.ρ]) == Symbol(sys.fluid.ρ)
+    @test Symbol(binds[sys.valve.port_b.ρ]) == Symbol(sys.fluid.ρ)
+    @test Symbol(binds[sys.valve.port_r.ρ]) == Symbol(sys.fluid.ρ)
+    @test Symbol(binds[sys.snk.port.ρ]) == Symbol(sys.fluid.ρ)
 
     @time sol = solve(prob, Rodas5P(); initializealg = NoInit())
 
@@ -356,7 +360,8 @@ end
         end
 
         eqs = [
-            connect(fluid, cap.port, vol.port)
+            domain_connect(fluid, cap.port, vol.port)
+            connect(cap.port, vol.port)
             connect(vol.flange, mass.flange)
         ]
 


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Use `domain_connect` for hydraulic domain propagation instead of routing flow equations through the fluid parameter setter.
- Keep the cap/volume physical connection explicit.
- Transfer the Actuator operating point with public symbolic problem indexing instead of pairing symbolic unknowns with raw solution storage.
- Check domain parameter propagation through the public `ModelingToolkitBase.bindings` API.
- Add source/volume flow-balance assertions to the DynamicVolume test.

## Root cause

ModelingToolkit commit `b0f315369` stopped silently zeroing underconstrained variables during alias elimination. The immediate parent `80f7f62bc` passes the reduced DynamicVolume model, while `b0f315369` reports 48 highest-order variables and 47 equations. The tests were using a fluid domain setter as a physical flow connector, which hid the model structure behind the removed zeroing behavior.

The Actuator test also copied a failed zero-length solution by zipping `unknowns(initsys)` with raw `initsol.u` storage. Its public problem operating point contains `piston.dx = 0`, while the copied raw value was `NaN`. Reading each unknown through `initprob[v]` preserves the intended operating point.

## Validation

- Rebased head `1cb83378` on current `main` `8539d8f2` (merged #477).
- Direct `test/isothermal_compressible.jl` on Julia 1.12.6, exit 0:
  - Fluid Domain and Tube: 2/2
  - Valve: 1/1
  - DynamicVolume and minimum-volume feature: 12/12
  - Actuator System: 9/9
  - Prevent Negative Pressure: 3/3
- Exact commit boundary with the same reduced model and local environment:
  - `80f7f62bc`: exit 0
  - `b0f315369`: exit 1, 48 variables / 47 equations
- Official `GROUP=Core Pkg.test()` on a temporary validation stack containing current main, this patch, and #480: Analog 100/100, Chua 1/1, Continuous 76/76, Digital 34/34, and Isothermal 27/27; the run then stopped on the separate clean-main exact-equality assertion in `test/magnetic.jl:66`, which is under an independent reproduction and ULP analysis.
- Repository-wide Runic 1.7 `--check .`: exit 0 across 81 files.
- `git diff --check`: exit 0.

No test was skipped, disabled, silenced, or made warn-only.

Related: #457, merged #477, and #480.