### PR TITLE
Fix callable interpolation builder symtype

### DIFF
--- a/src/Blocks/Blocks.jl
+++ b/src/Blocks/Blocks.jl
@@ -5,6 +5,7 @@ module Blocks
 using ModelingToolkitBase: ModelingToolkitBase, @component, @connector, @named,
     @parameters, @unpack, System, compose, connect, extend,
     getdefault, t_nounits as t, D_nounits as D
+using SymbolicUtils: @syms, symtype
 using Symbolics: Symbolics, @register_symbolic, @variables, Differential, Equation
 import Base: ifelse
 import ..@symcheck

--- a/src/Blocks/sources.jl
+++ b/src/Blocks/sources.jl
@@ -864,7 +864,15 @@ end
 
 Base.nameof(::CachedInterpolation) = :CachedInterpolation
 
-@register_symbolic (f::CachedInterpolation)(u::AbstractArray, x::AbstractArray, args::Tuple)
+const _INTERPOLATOR_SYMTYPE = let
+    @syms interpolator(::Real)::Real
+    symtype(interpolator)
+end
+
+# Calling the builder returns the interpolation function, not an interpolated scalar.
+@register_symbolic (f::CachedInterpolation)(
+    u::AbstractArray, x::AbstractArray, args::Tuple
+)::_INTERPOLATOR_SYMTYPE
 
 """
     ParametrizedInterpolation(interp_type, u, x, args...; name, t = ModelingToolkitBase.t_nounits)

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -14,6 +14,7 @@ using SymbolicIndexingInterface
 using SciMLStructures: SciMLStructures, Tunable
 using ForwardDiff
 using ADTypes
+using SymbolicUtils: symtype
 
 @testset "Constant" begin
     @named src = Constant(k = 2)
@@ -650,6 +651,9 @@ end
 
     @testset "LinearInterpolation" begin
         @named i = ParametrizedInterpolation(LinearInterpolation, u, x)
+        interpolator = only(values(bindings(i)))
+        @test symtype(interpolator(0.0)) === Real
+
         eqs = [i.input.u ~ t, D(y) ~ i.output.u]
 
         @named model = System(eqs, t, systems = [i])


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## Summary

- register `CachedInterpolation` as returning a callable `Real -> Real` symbolic value
- derive that callable symtype through public `SymbolicUtils.@syms` and `SymbolicUtils.symtype` APIs
- directly regress calling the bound interpolator before constructing and solving its `ODEProblem`

## Why

`@register_symbolic` otherwise gives the interpolation builder a scalar `Real` return type. The builder actually returns an interpolation function, so later symbolic calls fail with `fntype_X_Y(::Type{Real})`. This is the failure reported in SciML/ModelingToolkit.jl#4527 and reproduced by the ParametrizedInterpolation documentation example.

The implementation intentionally does not use `SymbolicUtils.FnType`, which is not public. The public construction was checked with both SymbolicUtils 4.40.0 and the package floor 4.38.1; in both cases the builder symtype is callable and calling it has symtype `Real`.

This final head is `eb23f169`, rebased on current upstream `d0243bd3` after #477 and #478 merged. The paired strict documentation repair and end-to-end build are in #481.

## Local validation

- Julia 1.12.6 focused reproduction: `problem=ODEProblem`, `retcode=Success`, `samples=8`
- final rebased full `test/sources.jl`: exit 0; ParametrizedInterpolation 10 passed and 1 pre-existing broken
- `GROUP=QA Pkg.test()` before the base-only #478 rebase: 19 passed, 19 total; the rebase changed only the unrelated isothermal test
- final stacked strict documentation build in #481: exit 0 through CrossReferences, CheckDocument, Populate, RenderDocument, HTMLWriter, and inventory generation
- repository-wide Runic check on the final rebased tree: exit 0
- `git diff --check`: exit 0

No test or example is skipped, disabled, loosened, or made warn-only by this PR.

## Independent failures observed

Current upstream already contains the Chua and isothermal repairs from #477 and #478. The official `GROUP=Core` run now progresses through those tests and stops at the untouched exact-equality assertion in `test/magnetic.jl:66`, where the residual is one floating-point ULP. That clean-main failure is under a separate bisect and focused audit; no unrelated numerical assertion is changed here.

An exploratory run with DataInterpolations 9.0.2 exposed an unrelated ForwardDiff error, but 9.x is outside this package's declared test compatibility (`DataInterpolations = "8"`). The supported resolver choice, 8.10.0, passes the complete source test file as reported above.
