### PR TITLE
Define the independent variable in the motor test

### DIFF
--- a/test/motor.jl
+++ b/test/motor.jl
@@ -1,4 +1,5 @@
 using ModelingToolkit, Test
+using ModelingToolkitBase: @independent_variables
 using SciCompDSL
 using SciMLBase
 using ModelingToolkitStandardLibrary.Thermal

--- a/test/motor.jl
+++ b/test/motor.jl
@@ -4,6 +4,8 @@ using SciMLBase
 using ModelingToolkitStandardLibrary.Thermal
 using ModelingToolkitStandardLibrary.Blocks
 
+@independent_variables t
+
 # https://doc.modelica.org/Modelica%204.0.0/Resources/helpWSM/Modelica/Modelica.Thermal.HeatTransfer.Examples.Motor.html
 
 @testset "Thermal Motor Demo" begin


### PR DESCRIPTION
> **Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Summary

- define the thermal motor test independent variable with the documented public `@independent_variables` macro
- import that macro directly from its declaring owner, ModelingToolkitBase, instead of relying on a ModelingToolkit re-export
- avoid the implicit SciCompDSL fallback for `t`, which is a `PleaseImportDynamicQuantities` sentinel when DynamicQuantities is absent from the minimum dependency environment
- keep the change limited to the standalone test; runtime code and dependencies are unchanged

Final head: `015b399e`, based on upstream `d0243bd3`.

## Root cause

The motor test was the only top-level test using `@mtkmodel` without defining or importing `t`. SciCompDSL therefore fell back to `ModelingToolkitBase.t`. With ModelingToolkit 11.2.0, ModelingToolkitBase 1.0.0, and SciCompDSL 1.0.1, that fallback is `ModelingToolkitBase.PleaseImportDynamicQuantities()` unless the DynamicQuantities extension is loaded, and `@mtkcompile motor = ThermalMotor()` fails in `_check_if_dde`.

A source-history bisect isolated the DynamicQuantities extension boundary:

- first sentinel commit: `2785a86207f9d96fbe4f9395a4346228a43e8dd3` (`refactor: move DynamicQuantities to extension`)
- parent: `ce0436f48c25553bcaa3b6bcd6421d1095e98bd1` (`refactor: move DiffEqNoiseProcess to extension`)

The historical parent cannot currently be instantiated from the registry because its intermediate SymbolicUtils 4 / Symbolics 6 constraints are unsatisfiable. The released failing dependency stack above was reproduced directly.

`@independent_variables` is exported by its owner ModelingToolkitBase, has an owner docstring in `lib/ModelingToolkitBase/src/independent_variables.jl`, and is included in the rendered API reference. ModelingToolkitBase is already a direct dependency of this package.

## Local verification

- exact minimum stack before this change: reproduced `_check_if_dde(::Vector{Equation}, ::ModelingToolkitBase.PleaseImportDynamicQuantities, ::Vector{System})`
- final exact minimum stack after the explicit owner import, with `OrdinaryDiffEq` preloaded as in native tests: `Thermal Motor Demo | Pass 6 / Total 6` (143.3 s, including first-use work)
- final current stack after the explicit owner import: `Thermal Motor Demo | Pass 6 / Total 6` (137.0 s, including first-use work)
- `GROUP=Core` on current upstream passed through `Core/isothermal_compressible.jl` (27/27), then stopped at the separately audited exact-equality assertion in `test/magnetic.jl:66` (2 passed, 1 failed), before reaching motor; the focused runs above execute motor end-to-end
- repository-wide Julia Runic check: exit 0 across all 81 tracked Julia files
- `git diff --check`: exit 0

No test is skipped, disabled, loosened, or made warn-only by this PR.

## Independent minimum-compatibility blocker

On current upstream, the downgrade workflow reaches an earlier ModelingToolkitBase 1.0 array-codegen failure in `test/continuous.jl` before motor. Focused draft #482 raises the ModelingToolkitBase floor to 1.1 and validates continuous 76/76. That independent fix is deliberately not duplicated here; the exact minimum-stack focused motor run above verifies this PR's test after preloading the native solver stack.