### PR TITLE
test: bound reconstructed magnetic flux balance by ULPs

### DIFF
--- a/test/magnetic.jl
+++ b/test/magnetic.jl
@@ -63,5 +63,12 @@ using OrdinaryDiffEqRosenbrock: Rodas4
 
     @test SciMLBase.successful_retcode(sol)
     @test sol[r_mFe.Phi] == sol[r_mAirPar.Phi]
-    @test all(sol[coil.port_p.Phi] + sol[r_mLeak.Phi] + sol[r_mAirPar.Phi] .== 0)
+    coil_flux = sol[coil.port_p.Phi]
+    leakage_flux = sol[r_mLeak.Phi]
+    air_flux = sol[r_mAirPar.Phi]
+    flux_balance = coil_flux + leakage_flux + air_flux
+    flux_scale = maximum(maximum(abs, flux) for flux in (coil_flux, leakage_flux, air_flux))
+    # Exact cancellation is lost when observables are reconstructed; four ULPs covers that
+    # roundoff and the two additions.
+    @test maximum(abs, flux_balance) <= 4 * eps(flux_scale)
 end


### PR DESCRIPTION
Please ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- Replace exact equality for a sum of three reconstructed magnetic-flux observables with an absolute four-ULP bound derived from their simulated scale.
- Keep the test sensitive to physical flux-balance regressions without assuming that reconstructed `Float64` observables cancel bit-for-bit after two additions.

## Root cause and boundary

The connector equation remains symbolically exact, but ModelingToolkit's perfect-alias elimination changes which fluxes are solved directly and which are reconstructed as observables. The queried `Float64` values therefore accumulate reconstruction and summation roundoff even though the physical balance is unchanged.

The release boundary is ModelingToolkit 11.19 (passes) to 11.20 (fails). Companion-only controls pass with MTK 11.19 + MTKBase 1.29.1 and with MTK 11.19 + MTKTearing 1.12.1. On an otherwise identical Julia 1.12.6 / MTKBase 1.29.1 / MTKTearing 1.12.1 stack:

- `a4bf0bd37e`, the parent of the alias-elimination change: 3/3 pass.
- `c49d619f6c` (`feat: eliminate perfect aliases in favor of higher priority variables`): 2/3, failing only the exact flux-balance equality.

Older boundary checks also pass with MTKSL 2.21.1 / MTK 9.84, MTKSL 2.22.0 / MTK 10.32, and current MTKSL source with MTK 11.0, 11.15, 11.18, and 11.19. MTK 11.20 and current MTK 11.31 reproduce the one-ULP residual.

The observed maximum residual is `2.168404344971009e-19`, exactly `eps(flux_scale)`, at a maximum flux scale of about `1.72464e-3`. It is unchanged with `abstol = reltol = 1e-12` and across Julia 1.10, 1.12, and 1.13 RC. The new ceiling is `4 * eps(flux_scale)`, an absolute-only bound of about `8.67e-19` that covers three reconstructed values and two additions while remaining sensitive at roughly `5e-16` relative to the flux scale.

## Validation

- Julia 1.10.11 focused `test/magnetic.jl`: 3/3 pass.
- Julia 1.12.6 focused `test/magnetic.jl`: 3/3 pass.
- Julia 1.13.0-rc1 focused `test/magnetic.jl`: 3/3 pass (after pre-existing stdlib package-image warnings).
- Native `GROUP=Core` on current upstream: `Core/magnetic.jl` passes 3/3; the run then stops at the separately bisected clean-main `Core/motor.jl` `_check_if_dde(::Vector{Equation}, ::PleaseImportDynamicQuantities, ...)` error.
- Full-repository Runic check: pass.
- `git diff --check`: pass.
