### PR TITLE
Define the piston test independent variable

### DIFF
--- a/test/piston.jl
+++ b/test/piston.jl
@@ -1,8 +1,11 @@
 using ModelingToolkit, Test
+using ModelingToolkitBase: @independent_variables
 using SciCompDSL
 using SciMLBase
 using ModelingToolkitStandardLibrary.Thermal
 using ModelingToolkitStandardLibrary.Blocks
+
+@independent_variables t
 
 # Tests ConvectiveResistor and includes FixedTemperature and ThermalResistor
 


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Import the public `@independent_variables` macro from its owning `ModelingToolkitBase` module.
- Define the piston test's independent variable explicitly instead of inheriting ModelingToolkit's extension-import sentinel.

## Context

ModelingToolkit source-history bisection identified `2785a86207f9d96fbe4f9395a4346228a43e8dd3` (`refactor: move DynamicQuantities to extension`) as the commit that replaced the global independent variable with `PleaseImportDynamicQuantities`. ModelingToolkitStandardLibrary PR #483 defined an independent variable for `motor.jl`, but `piston.jl` still reproduced the same `_check_if_dde(::Vector{Equation}, ::PleaseImportDynamicQuantities, ::Vector{System})` `MethodError` against current ModelingToolkit master.

This uses the same public-owner import pattern as #483 and changes only the test fixture.

## Local verification

- Before the change, `include("test/piston.jl")` reproduced the `PleaseImportDynamicQuantities` `MethodError`.
- After rebasing onto MTSL main `2a9fc95e`, the focused test passed: `Piston cylinder wall | Pass 3 | Total 3 | 2m08.1s`.
- In `GROUP=Core`, `Core/motor.jl` passed 6/6 and `Core/piston.jl` passed 3/3. The run later stopped on unrelated `Core/rotational.jl` failures that also reproduce on an unmodified MTSL main checkout and are being investigated separately.
- `/home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no -m Runic --check .` exited 0.
- `git diff --check` exited 0.
