### PR TITLE
Fix rotational mechanics initialization and torque balance

### DIFF
--- a/src/Mechanical/Rotational/sensors.jl
+++ b/src/Mechanical/Rotational/sensors.jl
@@ -83,6 +83,7 @@ Ideal sensor to measure the torque between two flanges (`= flange_a.tau`)
     end
 
     equations = Equation[
+        0 ~ flange_a.tau + flange_b.tau,
         flange_a.phi ~ flange_b.phi,
         tau.u ~ flange_a.tau,
     ]

--- a/test/piston.jl
+++ b/test/piston.jl
@@ -1,8 +1,11 @@
 using ModelingToolkit, Test
+using ModelingToolkitBase: @independent_variables
 using SciCompDSL
 using SciMLBase
 using ModelingToolkitStandardLibrary.Thermal
 using ModelingToolkitStandardLibrary.Blocks
+
+@independent_variables t
 
 # Tests ConvectiveResistor and includes FixedTemperature and ThermalResistor
 

--- a/test/rotational.jl
+++ b/test/rotational.jl
@@ -104,7 +104,13 @@ end
     @test SciMLBase.successful_retcode(sol)
 
     prob = ODEProblem(
-        sys, [D(D(sys.inertia2.phi)) => 0.0, sys.spring.flange_b.phi => 0.0], (0, 1.0)
+        sys,
+        [
+            sys.inertia1.w => 0.0,
+            sys.inertia2.w => 0.0,
+            sys.spring.flange_b.phi => 0.0,
+        ],
+        (0, 1.0)
     )
     sol = solve(prob, Rodas4())
     @test SciMLBase.successful_retcode(sol)
@@ -287,7 +293,7 @@ end
     @test all(sol[sys.inertia1.w] .== sol[sys.speed_sensor.w.u])
     @test sol[sys.inertia2.w][end] ≈ 0 atol = 1.0e-3 # all energy has dissipated
     @test all(sol[sys.rel_speed_sensor.w_rel.u] .== sol[sys.speed_sensor.w.u])
-    @test all(sol[sys.torque_sensor.tau.u] .== -sol[sys.inertia1.flange_b.tau])
+    @test all(sol[sys.torque_sensor.tau.u] .== -sol[sys.fixed.flange.tau])
 
     prob = DAEProblem(
         sys, D.(unknowns(sys)) .=> prob.f(sol.u[1], prob.p, 0.0), (0, 10.0)
@@ -298,7 +304,7 @@ end
     @test all(sol[sys.inertia1.w] .== sol[sys.speed_sensor.w.u])
     @test sol[sys.inertia2.w][end] ≈ 0 atol = 1.0e-3 # all energy has dissipated
     @test all(sol[sys.rel_speed_sensor.w_rel.u] .== sol[sys.speed_sensor.w.u])
-    @test all(sol[sys.torque_sensor.tau.u] .== -sol[sys.inertia1.flange_b.tau])
+    @test all(sol[sys.torque_sensor.tau.u] .== -sol[sys.fixed.flange.tau])
 
     # Plots.plot(sol; vars=[inertia1.w, inertia2.w])
 end


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

> Depends on #485. This branch is stacked on that piston-test fix so CI can exercise the rotational changes on a complete green baseline. Once #485 merges, this PR will reduce to the rotational commit.

## Summary

- Initialize both driven inertias at zero angular velocity instead of constraining an acceleration in the ODE test.
- Restore the two-flange torque balance that was lost when `TorqueSensor` moved from `@mtkmodel` to `@component`.
- Check the measured torque against the fixed support reaction, which is its exact physical counterpart in this test topology.

The existing `atol = 1` conservation check is unchanged.

## Root cause

With the acceleration constraint, the preloaded spring and damper force the second inertia to start at `500π` rad/s. On current ModelingToolkit this produced:

```text
w1_initial = 0.0
w2_initial = 1570.7963267948967
maximum_residual = 3141.910963169249
count_residual_gt_1 = 101
```

Explicitly starting both inertias from rest gives a maximum conservation residual of `0.31813746890592665`, below the unchanged tolerance.

The missing `TorqueSensor` flow balance separately left the sensor model with 23 highest-order variables and 22 equations. After restoring it, the sensor torque is exactly opposite the fixed support reaction (`maximum(abs.(sensor_tau .+ fixed_tau)) == 0.0`).

Source-history bisects identified:

- `27fa668cc920d1de71d724978b926e43758e3526` (`test(Rotational): fix offsets and sol definitions`) as the first commit with the current driven-inertia initialization/offset pattern.
- `5d56791e142853b1eeeb34eccdaa7a4edfc430dc` (`refactor: use @component syntax instead of @mtkmodel`) as the first commit where `TorqueSensor` no longer receives the connector flow balance generated by `@mtkmodel`.

## Verification

Against ModelingToolkit `34ee9182900688f8545d61fb92d143ed29a8ad7f` on Julia 1.12.6, in separate processes:

```text
Piston cylinder wall                 |  3 pass /  3 total
two inertias                         |  6 pass /  6 total
two inertias with driving torque     |  6 pass /  6 total
first example                        |  1 pass /  1 total
Stick-Slip                           |  2 pass /  2 total
sensors                              | 12 pass / 12 total
Position                             |  4 pass /  4 total
```

Also passed:

```text
Runic 1.7.0 --check: exit 0
git diff --check: exit 0
```
