### PR TITLE
Initialize the FixedHeatFlow algebraic state

### DIFF
--- a/test/thermal.jl
+++ b/test/thermal.jl
@@ -196,7 +196,17 @@ end
 
     @info "Building a FixedHeatFlow with alpha=0.0"
     @mtkcompile test_model = TestModel() allow_parameter = false
-    prob = ODEProblem(test_model, [test_model.wall.Q_flow => nothing, test_model.wall.dT => nothing], (0, 10.0); guesses = [test_model.heatflow.port.T => 1.0])
+    # A 1 W flow across the 1 K/W wall puts this port 1 K below the 300 K source.
+    prob = ODEProblem(
+        test_model,
+        [
+            test_model.wall.Q_flow => nothing,
+            test_model.wall.dT => nothing,
+            test_model.heatflow.port.T => 299.0,
+        ],
+        (0, 10.0);
+        guesses = [test_model.heatflow.port.T => 1.0],
+    )
     sol = solve(prob)
 
     heat_flow = sol[test_model.heatflow.port.Q_flow]


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Initialize the remaining FixedHeatFlow port temperature to its physical 299 K value in the thermal regression test.
- Preserve the original solver, assertions, expected values, and tolerances.

## Why

The exact downgrade workflow graph selected by julia-actions/julia-downgrade-compat at `fab1defb76df9fd672f63c94df73ce131d32e134` uses ModelingToolkit 11.2.0. On clean main, that graph leaves the only reduced state at `Inf`, so initialization returns `InitialFailure` even though the observed heat flow is already 1 W. A 1 W flow across the 1 K/W wall places this port 1 K below the 300 K source, so the explicit 299 K initial value is model-consistent.

Commit `c44704f3` is the repository boundary that made the empty-GROUP downgrade invocation execute Core tests. The earlier apparent green run failed during precompilation and then executed zero tests. With current ModelingToolkit 11.31.2, the same model derives 299 K and succeeds without the explicit value; the added fixture keeps the minimum-compatible graph valid.

Draft #485 independently addresses the clean-main piston failure encountered later in Core. This PR deliberately leaves the piston model unchanged.

## Local validation

- Exact downgraded graph, Julia 1.10.11: `include("test/thermal.jl")` — 19/19 passed, including FixedHeatFlow 2/2.
- Native `GROUP=Core Pkg.test()` on the exact downgraded graph: every preceding file passed through nonlinear 15/15; execution then reached the known clean-main piston error addressed by draft #485.
- Runic 1.7 whole-repository check: passed.
- `git diff --check`: passed.