### PR TITLE
Fix underdetermined thermal heat-flow sensor test

### DIFF
--- a/test/thermal.jl
+++ b/test/thermal.jl
@@ -74,14 +74,9 @@ end
     @info "Building a heat-flow system..."
     eqs = [
         connect(mass1.port, th_resistor.port_a, th_conductor.port_a)
-        connect(
-            th_conductor.port_b, flow_src.port, hf_sensor1.port_a,
-            hf_sensor2.port_a
-        )
-        connect(
-            th_resistor.port_b, hf_sensor1.port_b, hf_sensor2.port_b,
-            th_ground.port
-        )
+        connect(th_conductor.port_b, flow_src.port, hf_sensor1.port_a)
+        connect(hf_sensor1.port_b, hf_sensor2.port_a)
+        connect(th_resistor.port_b, hf_sensor2.port_b, th_ground.port)
     ]
     @named h2 = System(
         eqs, t,
@@ -99,6 +94,7 @@ end
     @test SciMLBase.successful_retcode(sol)
     @test sol[th_conductor.dT] .* G == sol[th_conductor.Q_flow]
     @test sol[th_conductor.Q_flow] ≈ sol[hf_sensor1.Q_flow.u] + sol[flow_src.port.Q_flow]
+    @test sol[hf_sensor1.Q_flow.u] == sol[hf_sensor2.Q_flow.u]
 
     @test sol[mass1.T] == sol[th_resistor.port_a.T]
     @test sol[th_resistor.dT] ./ R ≈ sol[th_resistor.Q_flow]


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Connect the two ideal `HeatFlowSensor`s in series instead of in parallel.
- Keep both sensors in the test and assert that they report exactly the same through-flow.

## Why

The parallel topology connects both ideal sensors across the same two thermal nodes. Their zero-temperature-drop equations are duplicates, while the node balances constrain only the sum of the two sensor flows. The individual flow split is therefore arbitrary, producing the observed structural imbalance (11 highest-order variables and 10 equations on the current stack).

Putting the sensors in series gives each sensor a uniquely determined through-flow without changing production code. This also preserves the original heat-flow assertion and adds a direct regression assertion for both sensor readings.

The invalid parallel topology dates to the initial thermal test upload (`ae289f4d`). A local release boundary probe with the unchanged fixture passes on ModelingToolkit v10.31.0 and is detected as structurally singular on v10.31.1. The detecting source change is ModelingToolkit commit `3eef54d43a752f7a46a0f53689d5f557115299f9`, which moves consistency checking before alias elimination so alias-added zero constraints no longer mask underdetermination.

The output-marking approach explored in #450 does not change structural balance; #452 also identified the parallel sensors.

## Verification

- Julia 1.10.11, exact current dependency graph: full `test/thermal.jl` passes (Heat systems 6/6, Heat flow system 6/6, Radiator 3/3, Thermal Collector 3/3, FixedHeatFlow 2/2).
- Julia 1.12.6, exact current dependency graph: full `test/thermal.jl` passes with the same counts.
- Julia 1.13.0-rc1, exact current dependency graph: full `test/thermal.jl` passes with the same counts.
- `Runic --check .` passes on the full repository.
- `git diff --check` passes.

A clean-main `GROUP=Core` run was also attempted locally. It reaches the pre-existing piston missing-independent-variable failure before the thermal file; the targeted thermal suite above was therefore run directly on all three Julia versions.
