### PR TITLE
Initialize translational acceleration sensor test

### DIFF
--- a/test/translational.jl
+++ b/test/translational.jl
@@ -249,7 +249,9 @@ end
                 eqs, t, [], []; systems = [force, source, mass, acc, acc_output]
             )
             s = complete(mtkcompile(sys))
-            prob = ODEProblem(s, [], (0.0, pi), fully_determined = true)
+            prob = ODEProblem(
+                s, [s.mass.s => 0, s.mass.v => 0], (0.0, pi); fully_determined = true
+            )
             sol = solve(prob, Tsit5())
             @test sol[sys.acc_output.u] ≈ (sol[sys.mass.f] ./ m)
         end


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Initialize both physical states of the `TranslationalPosition.AccelerationSensor` test mass.
- Keep the existing fully determined initialization check and acceleration-versus-force assertion.

## Root cause

The test constructed `TranslationalPosition.Mass(m = 4)` and then passed no initial conditions to `ODEProblem(...; fully_determined = true)`. Current ModelingToolkit therefore correctly reports an underdetermined initialization system rather than selecting arbitrary initial position and velocity values.

ModelingToolkit source-history bisection identified `b0f31536949370d189c03df71bc38f692a9a6975` (`fix: avoid false positives in consistency check`) as the first bad commit for this fixture:

- Parent `80f7f62bc0a8925dfef88f149c111c6dc812415e` constructed the problem only because alias elimination silently forced underconstrained variables to zero.
- `b0f3153694` intentionally replaced that behavior with `IgnoreUnderconstrainedVariable`; the same fixture then reported 4 highest-order derivative variables for 2 equations, including `mass₊sˍt(t)` and `acc₊flange₊s(t)`.

Giving the mass explicit zero position and velocity is the physical assumption the test already relied on. This is distinct from the closed `outputs=` attempt in #450: outputs do not change structural balance. An explicit internal velocity inside `AccelerationSensor` was also tested and did not fix initialization; it only moved the singular variable.

## Local verification

Using registry ModelingToolkit 11.31.2 and ModelingToolkitBase 1.51.1:

- Julia 1.12.6, exact PR head on MTSL main `06464384`: `test/translational.jl` passed 16/16 (`Free` 2/2; spring/damper/mass/fixed 4/4; driven 4/4; sources and sensors 6/6).
- Julia 1.10.11, exact PR head: the same file passed 16/16.
- A focused solve with both initial conditions passed the existing physical assertion `acc_output ≈ mass.f / m`.
- Runic checked all 81 tracked Julia files successfully.
- `git diff --check` passed.

## Process log

1. Searched open/closed issues and PRs, including #457 and closed PR #450.
2. Reproduced the failure independently on clean MTSL main with the reported dependency versions.
3. Tested and rejected the `outputs=` and internal-velocity hypotheses.
4. Confirmed that both physical mass initial conditions are necessary and sufficient.
5. Bisected the behavior to ModelingToolkit commit `b0f3153694` and inspected its removal of silent zeroing.
6. Rebasing onto current MTSL main, reran the focused file on Julia 1.12 and 1.10, then ran Runic and the diff check.
