### PR TITLE
Initialize translational acceleration sensor mass

### DIFF
--- a/test/translational.jl
+++ b/test/translational.jl
@@ -235,7 +235,7 @@ end
         @testset "AccelerationSensor" begin
             @named acc = TP.AccelerationSensor()
             m = 4
-            @named mass = TP.Mass(m = m)
+            @named mass = TP.Mass(m = m, s = 0, v = 0)
             @named force = TP.Force()
             @named source = Sine(frequency = 2, amplitude = 1)
             @named acc_output = RealOutput()


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- initialize the TranslationalPosition acceleration-sensor fixture's mass position and velocity at component construction
- keep the fixture fully determined under current ModelingToolkit initialization checks

## Root cause

`TP.Mass` stopped supplying `s = 0` and `v = 0` defaults in #305, but this fixture continued constructing it with only `m`. ModelingToolkit v11.10.0 exposed that underconstraint after `b0f31536949370d189c03df71bc38f692a9a6975` stopped alias elimination from silently zeroing underconstrained variables. With ModelingToolkit v11.31.2, `ODEProblem(...; fully_determined = true)` therefore reports a structurally singular `mass₊v(t)` initialization system.

Providing the initial state on `TP.Mass` is the smallest fix and establishes the state before `mtkcompile`. This extracts the same focused fixture correction from the broader #452; the `outputs` approach attempted in #450 does not alter structural balance.

## Local verification

- Julia 1.10.11: `test/translational.jl` — 16/16 passed
- Julia 1.12.6: `test/translational.jl` — 16/16 passed after rebasing onto `06464384`
- Julia 1.13.0-rc1: `test/translational.jl` — 16/16 passed
- explicit acceleration diagnostic — maximum error against `sin(4πt) / 4` was `0.0`
- Runic v1.7.0: full-repository `--check` exited 0
- native stacked `GROUP=Core` with #485–#488: `Core/translational.jl` passed 16/16; the overall group later exited 1 in the unrelated `Core/utils.jl` SISO check, which is being handled as a separate clean-main audit
