### PR TITLE
test: exercise SISO initialization through ODEProblem

### DIFF
--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,7 +1,7 @@
 using ModelingToolkitStandardLibrary.Blocks
 using SciCompDSL
 using ModelingToolkit
-using OrdinaryDiffEq
+using SciMLBase: ODEProblem
 using ModelingToolkit: t_nounits as t, D_nounits as D
 using Symbolics
 
@@ -34,11 +34,10 @@ end
     @named iosys = System(connect(c.output, so.input), t, systems = [so, c])
     sys = mtkcompile(iosys)
 
-    initprob = ModelingToolkit.InitializationProblem(sys, 0.0)
-    initsol = solve(initprob)
+    prob = ODEProblem(sys, Dict{Any, Any}(), (0.0, 1.0))
 
-    @test initsol[sys.so.xd] == 1.0
-    @test initsol[sys.so.u] == 1.0
+    @test prob[sys.so.xd] == 1.0
+    @test prob[sys.so.u] == 1.0
 end
 
 @test_deprecated RealInput(; name = :a, u_start = 1.0)


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## Summary

- Construct the SISO test's initialized system through `ODEProblem` instead of solving the standalone `InitializationProblem`.
- Keep both behavioral assertions exact and unchanged at `1.0`.
- Import `ODEProblem` from its declaring public module, `SciMLBase`, and remove the now-unused `OrdinaryDiffEq` import.

This is a focused extraction of the SISO change from draft PR #452. That PR contains unrelated changes and conflicts; none of those changes are included here. The branch is now rebased on current `main` after #489 merged, so this PR contains one commit and changes only `test/utils.jl`.

## Root cause

PR #469 replaced the old manual `generate_initializesystem` / `NonlinearProblem` path with `InitializationProblem`. A standalone initialization problem is keyed to its intermediate initialization system, not the fully initialized original ODE system. This has two resolver-dependent failure modes:

- Older minimum-compatible stack: `initsol[sys.so.xd]` is `0.0`, not the declared `1.0` initial value.
- Current downgrade stack: `sys.so.u` has been eliminated from the initialization system, so indexing it throws `ArgumentError: Symbol so₊u(t) is not present in the system`.

`ODEProblem` performs the complete operating-point / initialization preprocessing and retains the public indexing semantics for both original states and observed variables. The test still checks exactly the same two values; it now checks them on the object whose initialization behavior matters to users.

A signature-specific source bisect identifies `3672b875` (PR #469) as the first commit producing the missing-observed-symbol behavior; its parent `a79a77f3` passes this SISO check on the preserved graph. `git log --follow` confirms #469 is still the latest `main` edit to this test.

## Exact current-main reproduction

The current-main downgrade run [29870067371](https://github.com/SciML/ModelingToolkitStandardLibrary.jl/actions/runs/29870067371), [job 88767752470](https://github.com/SciML/ModelingToolkitStandardLibrary.jl/actions/runs/29870067371/job/88767752470), fails at `test/utils.jl:41` with the missing-`so₊u` error: 13 pass / 1 error in `Core/utils.jl`.

I replayed exact main `4459350cf3dc5db67ab330ed9f2f8965a3aae1af` and this one-commit candidate from fresh isolated depots with Julia 1.10.11. Both used exact action commit `fab1defb76df9fd672f63c94df73ce131d32e134`, the workflow's strict `deps` resolution, stdlib skip list, and `Mooncake` no-promote setting. All 171 installed package/version pairs match the hosted job, and the base/candidate manifests are byte-identical (SHA-256 `fb0b7750f5a20e677cc23eb4e6ff3d8686829c95ee61bced6b6dcc399df0dc29`).

- Exact clean main: official `GROUP=Core` exited 1 with **587 pass / 3 broken / 1 error** across 19 files, reproducing the hosted `so₊u` signature.
- Exact candidate `8b156503`: the same official `GROUP=Core` invocation exited 0 with **588 pass / 3 broken / 0 fail / 0 error**, ending with `Testing ModelingToolkitStandardLibrary tests passed`.
- Candidate `Core/translational.jl`: 16/16 passed, confirming the merged #489 fix is included through the base rather than duplicated here.
- Candidate `Core/utils.jl`: 14/14 passed, including SISO 2/2 with both exact `1.0` assertions unchanged.
- Runic 1.7.0 `--check` passed for the repository root.
- `git diff --check` passed.

Earlier focused validation also passed the complete `test/utils.jl` on Julia 1.10.11 minimum/current graphs and Julia 1.12.6 current dependencies; the exact current-main full-harness replay above supersedes the former stacked-branch qualification.
