### PR TITLE
test: check SISO initialization via ODEProblem

### DIFF
--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,7 +1,7 @@
 using ModelingToolkitStandardLibrary.Blocks
 using SciCompDSL
 using ModelingToolkit
-using OrdinaryDiffEq
+using SciMLBase: ODEProblem
 using ModelingToolkit: t_nounits as t, D_nounits as D
 using Symbolics
 
@@ -34,11 +34,10 @@ end
     @named iosys = System(connect(c.output, so.input), t, systems = [so, c])
     sys = mtkcompile(iosys)
 
-    initprob = ModelingToolkit.InitializationProblem(sys, 0.0)
-    initsol = solve(initprob)
+    prob = ODEProblem(sys, [], (0.0, 1.0))
 
-    @test initsol[sys.so.xd] == 1.0
-    @test initsol[sys.so.u] == 1.0
+    @test prob[sys.so.xd] == 1.0
+    @test prob[sys.so.u] == 1.0
 end
 
 @test_deprecated RealInput(; name = :a, u_start = 1.0)


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Summary

- exercise the SISO initialization assertions through `SciMLBase.ODEProblem`
- keep both exact checks (`xd == 1.0` and `u == 1.0`) unchanged
- remove the test-only `OrdinaryDiffEq` import because this test no longer solves a standalone initialization problem

This is a fresh, focused extraction of the SISO test-path correction discussed in the stale omnibus #452. It does not include any of #452's unrelated changes.

## Why

PR #469 changed this test from the earlier explicit `generate_initializesystem`/`mtkcompile`/`NonlinearProblem` flow to `InitializationProblem(sys, 0.0)`, then indexed that standalone problem's solution with symbols from the original ODE system.

A standalone `InitializationProblem` represents the generated initialization system. Its symbolic container is not a contract that every original ODE unknown or observed alias remains indexable, and its intermediate unknown/default representation varies across compatible dependency graphs:

- current graph: `xd` initializes to `1.0`, while indexing `so.u` errors because that alias is not present in the generated initialization system
- preserved minimum graph (`ModelingToolkit 11.0.0`, `ModelingToolkitBase 1.1.0`, `Symbolics 7.4.1`, `SciMLBase 2.125.0`): the standalone path returns `xd == 0.0` and `u == 1.0`
- on that same minimum graph, the pre-#469 explicit path returns `xd == 1.0` and `u == 1.0`

The public `ODEProblem` construction is the operation whose contract the test actually wants: it runs initialization for the ODE and retains the original system as the symbolic provider. Both original assertions therefore remain exact and continue to test the intended initialized values.

## Local validation

- Julia 1.10.11, current resolved graph, complete `test/utils.jl`: 8/8 passed
- Julia 1.12.6, current resolved graph, complete `test/utils.jl`: 8/8 passed
- Julia 1.13.0-rc1 with `--compiled-modules=no`, current graph, complete `test/utils.jl`: 8/8 passed (source mode was needed because the local stdlib JLL cache had incompatible precompile flags)
- preserved exact minimum graph, focused public `ODEProblem` path: `xd == 1.0`, `u == 1.0`
- whole-repository `Runic --check .`: exit 0
- `git diff --check`: exit 0

`GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` ran all preceding Core files successfully, then exited 1 at the known clean-main `AccelerationSensor` error in `test/translational.jl:235` (`InvalidSystemException`, structurally singular `mass₊v(t)`). That unrelated base failure is addressed separately by #490; this PR does not alter or include that fix.

## Investigation steps

1. Reproduced both reported SISO symptoms on an unmodified current checkout and a preserved exact minimum manifest.
2. Inspected the compiled ODE system and generated initialization systems to identify the symbol-container mismatch.
3. Re-ran the pre-#469 path on the exact minimum graph to locate the source boundary.
4. Validated the public `ODEProblem` path on current Julia 1.10/1.12/1.13 and the exact minimum dependency graph.
5. Ran the repository-native Core harness, whole-repository Runic, and whitespace checks.
