### PR TITLE
Bump ModelingToolkitStandardLibrary to v2.29.5 for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkitStandardLibrary"
 uuid = "16a59e39-deab-5bd0-87e4-056b12336739"
-version = "2.29.4"
+version = "2.29.5"
 authors = ["Chris Rackauckas and Julia Computing"]
 
 [deps]


### PR DESCRIPTION
Bumps `ModelingToolkitStandardLibrary` 2.29.4 → 2.29.5 so the unreleased bug fix on main gets registered.

Unreleased since v2.29.4:
- 06464384 — Fix rotational mechanics initialization and torque balance (#486)

## Verification
Detected by comparing the `git-tree-sha1` of the latest registered version in the General registry against the `src` tree on `main`: they differ, so the code above is on master but not in any released version.

**No test suite was run locally for this PR** — it changes only the `version` field in `Project.toml` and adds no code. CI on this PR is the check that matters.

Please ignore until reviewed by @ChrisRackauckas.