### PR TITLE
Run downgrade CI on pushes to main

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -7,7 +7,7 @@ on:
       - 'docs/**'
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
 jobs:


### PR DESCRIPTION
## Summary

- run the `Downgrade` workflow after pushes to the repository's actual default branch, `main`
- leave pull-request filtering, path filtering, the reusable workflow, and the downgrade configuration unchanged

## Root cause

The repository moved from `master` to `main`, but the historical branch-reference update changed only the `pull_request` target in `Downgrade.yml`. The `push` target remained `master`, so merges to the default branch did not trigger the downgrade workflow.

## Impact

Merged default-branch changes will again receive strict minimum-version coverage. This is a workflow-trigger-only change; it does not alter package behavior or dependency bounds.

## Validation

- `actionlint -verbose .github/workflows/Downgrade.yml` — exit 0, zero parse/rule errors
- `julia +1.12 --startup-file=no --project=../../audit/runic_env -m Runic --check --diff .` — exit 0, no formatting diff
- shell assertion over the `push` block — exactly one `main` target and no `master` target
- `git diff --check` — exit 0

Package tests were not run because the only changed datum is a GitHub Actions event filter; the package source, tests, dependency bounds, and reusable downgrade job are untouched.

## Known independent failure

An exact version-only run on clean `main` can expose the existing SISO initialization failure. Draft #491 addresses that package behavior separately. This PR neither hides that failure nor duplicates its fix.

## Process

- fetched the canonical repository and verified the authenticated fork's `main` is at the same commit (`06464384`)
- inspected the workflow's full history and the prior canonical-CI PRs before editing
- made the one-line change on a feature branch and pushed it without force

Ignore this PR until it has been reviewed by @ChrisRackauckas.
