### PR TITLE
Fix Documenter binding references

### DIFF
--- a/src/Electrical/Analog/ideal_components.jl
+++ b/src/Electrical/Analog/ideal_components.jl
@@ -33,14 +33,14 @@ Generic resistor with optional temperature dependency.
 
 # States:
 
-  - See [OnePort](@ref)
+  - See [`OnePort`](@ref)
   - `R(t)`: [`Ω`] Resistance (temperature dependent if `T_dep = true`)
 
 # Connectors:
 
   - `p` Positive pin
   - `n` Negative pin
-  - `heat_port` [HeatPort](@ref) (only if `T_dep = true`) Heat port to model the temperature dependency
+  - `heat_port` [`HeatPort`](@ref) (only if `T_dep = true`) Heat port to model the temperature dependency
 
 # Parameters:
 
@@ -100,7 +100,7 @@ Creates an ideal conductor.
 
 # States:
 
-See [OnePort](@ref)
+See [`OnePort`](@ref)
 
 # Connectors:
 
@@ -141,7 +141,7 @@ Initial voltage of capacitor can be set with `v` ([`V`])
 
 # States:
 
-See [OnePort](@ref)
+See [`OnePort`](@ref)
 
 # Connectors:
 
@@ -182,7 +182,7 @@ Initial current through inductor can be set with `i` ([`A`]).
 
 # States:
 
-See [OnePort](@ref)
+See [`OnePort`](@ref)
 
 # Connectors:
 
@@ -262,7 +262,7 @@ Short is a simple short cut branch. That means the voltage drop between both pin
 
 # States:
 
-See [OnePort](@ref)
+See [`OnePort`](@ref)
 
 # Connectors:
 
@@ -304,10 +304,10 @@ Electromotoric force (electric/mechanic transformer)
 
 # Connectors
 
-  - `p` [Pin](@ref) Positive pin
-  - `n` [Pin](@ref) Negative pin
-  - `flange` [Flange](@ref) Shaft of EMF shaft
-  - `support` [Support](@ref) Support/housing of emf shaft
+  - `p` [`Pin`](@ref) Positive pin
+  - `n` [`Pin`](@ref) Negative pin
+  - `flange` [`Flange`](@ref) Shaft of EMF shaft
+  - `support` [`Support`](@ref) Support/housing of emf shaft
 
 # Parameters:
 
@@ -350,13 +350,13 @@ Generic diode with optional temperature dependency.
 
 # States
 
-    - See [OnePort](@ref)
+    - See [`OnePort`](@ref)
 
 # Connectors
 
     - `p` Positive pin
     - `n` Negative pin
-    - `port` [HeatPort](@ref) (only if `T_dep = true`) Heat port to model variable temperature dependency
+    - `port` [`HeatPort`](@ref) (only if `T_dep = true`) Heat port to model variable temperature dependency
 
 # Parameters:
     
@@ -433,7 +433,7 @@ R = R_const + pos * R_ref * (1 + alpha * (port.T - T_ref))
 
 # States
 
-    - See [OnePort](@ref)
+    - See [`OnePort`](@ref)
     - `pos(t)`: Position of the wiper (normally 0-1)
     - `R(t)`: Resistance
 
@@ -442,7 +442,7 @@ R = R_const + pos * R_ref * (1 + alpha * (port.T - T_ref))
         - `p` Positive pin
         - `n` Negative pin
         - `position` RealInput to set the position of the wiper
-        - `port` [HeatPort](@ref) Heat port to model the temperature dependency
+        - `port` [`HeatPort`](@ref) Heat port to model the temperature dependency
 
 # Parameters
 

--- a/src/Electrical/Analog/sensors.jl
+++ b/src/Electrical/Analog/sensors.jl
@@ -113,8 +113,8 @@ consumed by a circuit.
 # States:
 
   - `power(t)`: [`W`] The power being consumed, given by the product of voltage and current
-  - See [VoltageSensor](@ref)
-  - See [CurrentSensor](@ref)
+  - See [`VoltageSensor`](@ref)
+  - See [`CurrentSensor`](@ref)
 
 # Connectors:
 

--- a/src/Electrical/Analog/sources.jl
+++ b/src/Electrical/Analog/sources.jl
@@ -5,13 +5,13 @@ Acts as an ideal voltage source with no internal resistance.
 
 # States:
 
-See [OnePort](@ref)
+See [`OnePort`](@ref)
 
 # Connectors:
 
   - `p` Positive pin
   - `n` Negative pin
-  - `V` [RealInput](@ref) Input for the voltage control signal, i.e. `V ~ p.v - n.v`
+  - `V` [`RealInput`](@ref) Input for the voltage control signal, i.e. `V ~ p.v - n.v`
 """
 @component function Voltage(; name)
     @named oneport = OnePort()
@@ -42,13 +42,13 @@ Acts as an ideal current source with no internal resistance.
 
 # States:
 
-See [OnePort](@ref)
+See [`OnePort`](@ref)
 
 # Connectors:
 
   - `p` Positive pin
   - `n` Negative pin
-  - `I` [RealInput](@ref) Input for the current control signal, i.e. `I ~ p.i
+  - `I` [`RealInput`](@ref) Input for the current control signal, i.e. `I ~ p.i
 """
 @component function Current(; name)
     @named oneport = OnePort()

--- a/src/Mechanical/Rotational/components.jl
+++ b/src/Mechanical/Rotational/components.jl
@@ -5,7 +5,7 @@ Flange fixed in housing at a given angle.
 
 # Connectors:
 
-  - `flange` [Flange](@ref)
+  - `flange` [`Flange`](@ref)
 
 # Parameters:
 
@@ -43,8 +43,8 @@ end
 
 # Connectors:
 
-  - `flange_a` [Flange](@ref) Left flange
-  - `flange_b` [Flange](@ref) Right flange
+  - `flange_a` [`Flange`](@ref) Left flange
+  - `flange_b` [`Flange`](@ref) Right flange
 
 # Parameters:
 
@@ -91,8 +91,8 @@ Linear 1D rotational spring
 
 # Connectors:
 
-  - `flange_a` [Flange](@ref)
-  - `flange_b` [Flange](@ref)
+  - `flange_a` [`Flange`](@ref)
+  - `flange_b` [`Flange`](@ref)
 
 # Parameters:
 
@@ -138,8 +138,8 @@ Linear 1D rotational damper
 
 # Connectors:
 
-  - `flange_a` [Flange](@ref)
-  - `flange_b` [Flange](@ref)
+  - `flange_a` [`Flange`](@ref)
+  - `flange_b` [`Flange`](@ref)
 
 # Parameters:
 
@@ -182,8 +182,8 @@ Linear 1D rotational spring and damper
 
 # Connectors:
 
-  - `flange_a` [Flange](@ref)
-  - `flange_b` [Flange](@ref)
+  - `flange_a` [`Flange`](@ref)
+  - `flange_b` [`Flange`](@ref)
 
 # Parameters:
 
@@ -233,9 +233,9 @@ This element characterizes any type of gear box which is fixed in the ground and
 
 # Connectors:
 
-  - `flange_a` [Flange](@ref)
-  - `flange_b` [Flange](@ref)
-  - `support` [Support](@ref) if `use_support == true`
+  - `flange_a` [`Flange`](@ref)
+  - `flange_b` [`Flange`](@ref)
+  - `support` [`Support`](@ref) if `use_support == true`
 
 # Parameters:
 
@@ -286,8 +286,8 @@ Friction model: "Armstrong, B. and C.C. de Wit, Friction Modeling and Compensati
 
 # Connectors:
 
-  - `flange_a` [Flange](@ref)
-  - `flange_b` [Flange](@ref)
+  - `flange_a` [`Flange`](@ref)
+  - `flange_b` [`Flange`](@ref)
 
 # Parameters:
 

--- a/src/Mechanical/Rotational/sensors.jl
+++ b/src/Mechanical/Rotational/sensors.jl
@@ -5,8 +5,8 @@ Ideal sensor to measure the absolute flange angle
 
 # Connectors:
 
-  - `flange`: [Flange](@ref) Flange of shaft from which sensor information shall be measured
-  - `phi`: [RealOutput](@ref) Absolute angle of flange
+  - `flange`: [`Flange`](@ref) Flange of shaft from which sensor information shall be measured
+  - `phi`: [`RealOutput`](@ref) Absolute angle of flange
 """
 @component function AngleSensor(; name)
     pars = @parameters begin
@@ -35,8 +35,8 @@ Ideal sensor to measure the absolute flange angular velocity
 
 # Connectors:
 
-  - `flange`: [Flange](@ref) Flange of shaft from which sensor information shall be measured
-  - `w`: [RealOutput](@ref) Absolute angular velocity of flange
+  - `flange`: [`Flange`](@ref) Flange of shaft from which sensor information shall be measured
+  - `w`: [`RealOutput`](@ref) Absolute angular velocity of flange
 """
 @component function SpeedSensor(; name)
     pars = @parameters begin
@@ -65,9 +65,9 @@ Ideal sensor to measure the torque between two flanges (`= flange_a.tau`)
 
 # Connectors:
 
-  - `flange_a`: [Flange](@ref) Left flange of shaft
-  - `flange_b`: [Flange](@ref) Left flange of shaft
-  - `tau`: [RealOutput](@ref) Torque in flange flange_a and flange_b (`tau = flange_a.tau = -flange_b.tau`)
+  - `flange_a`: [`Flange`](@ref) Left flange of shaft
+  - `flange_b`: [`Flange`](@ref) Left flange of shaft
+  - `tau`: [`RealOutput`](@ref) Torque in flange flange_a and flange_b (`tau = flange_a.tau = -flange_b.tau`)
 """
 @component function TorqueSensor(; name)
     pars = @parameters begin
@@ -98,9 +98,9 @@ Ideal sensor to measure the relative angular velocity
 
 # Connectors:
 
-  - `flange_a`: [Flange](@ref) Flange of shaft from which sensor information shall be measured
-  - `flange_b`: [Flange](@ref) Flange of shaft from which sensor information shall be measured
-  - `w`: [RealOutput](@ref) Absolute angular velocity of flange
+  - `flange_a`: [`Flange`](@ref) Flange of shaft from which sensor information shall be measured
+  - `flange_b`: [`Flange`](@ref) Flange of shaft from which sensor information shall be measured
+  - `w`: [`RealOutput`](@ref) Absolute angular velocity of flange
 """
 @component function RelSpeedSensor(; name, phi_rel = nothing)
     pars = @parameters begin

--- a/src/Mechanical/Rotational/sources.jl
+++ b/src/Mechanical/Rotational/sources.jl
@@ -31,8 +31,8 @@ Input signal acting as external torque on a flange
 
 # Connectors:
 
-  - `flange` [Flange](@ref)
-  - `tau` [RealInput](@ref)  Accelerating torque acting at flange `-flange.tau`
+  - `flange` [`Flange`](@ref)
+  - `tau` [`RealInput`](@ref)  Accelerating torque acting at flange `-flange.tau`
 
 # Parameters:
 
@@ -72,7 +72,7 @@ Constant torque source
 - `w`: Angular velocity of flange with respect to support (= der(phi))
 
 # Connectors:
-- `flange` [Flange](@ref)
+- `flange` [`Flange`](@ref)
 
 # Arguments:
 - `tau_constant`: The constant torque applied by the source
@@ -115,8 +115,8 @@ Forced movement of a flange according to a reference angular velocity signal
 
 # Connectors:
 
-  - `flange` [Flange](@ref)
-  - `w_ref` [RealInput](@ref) Reference angular velocity of flange with respect to support as input signal needs to be continuously differential
+  - `flange` [`Flange`](@ref)
+  - `w_ref` [`RealInput`](@ref) Reference angular velocity of flange with respect to support as input signal needs to be continuously differential
 
 # Parameters:
 

--- a/src/Mechanical/Rotational/utils.jl
+++ b/src/Mechanical/Rotational/utils.jl
@@ -53,8 +53,8 @@ Partial model for the compliant connection of two rotational 1-dim. shaft flange
 
 # Connectors:
 
-  - `flange_a` [Flange](@ref)
-  - `flange_b` [Flange](@ref)
+  - `flange_a` [`Flange`](@ref)
+  - `flange_b` [`Flange`](@ref)
 
 """
 @component function PartialCompliant(; name, phi_rel = nothing, tau = nothing)
@@ -94,8 +94,8 @@ Partial model for the compliant connection of two rotational 1-dim. shaft flange
 
 # Connectors:
 
-  - `flange_a` [Flange](@ref)
-  - `flange_b` [Flange](@ref)
+  - `flange_a` [`Flange`](@ref)
+  - `flange_b` [`Flange`](@ref)
 """
 @component function PartialCompliantWithRelativeStates(; name, phi_rel = nothing, w_rel = nothing, a_rel = nothing, tau = nothing)
     pars = @parameters begin
@@ -136,7 +136,7 @@ Partial model for a component with one rotational 1-dim. shaft flange and a supp
 
 # Connectors:
 
-  - `flange` [Flange](@ref)
+  - `flange` [`Flange`](@ref)
 
 # Parameters:
 
@@ -172,9 +172,9 @@ Partial model for a component with two rotational 1-dim. shaft flanges and a sup
 
 # Connectors:
 
-  - `flange_a` [Flange](@ref)
-  - `flange_b` [Flange](@ref)
-  - `support` [Support](@ref)  if `use_support == true`
+  - `flange_a` [`Flange`](@ref)
+  - `flange_b` [`Flange`](@ref)
+  - `support` [`Support`](@ref)  if `use_support == true`
 
 # Parameters:
 

--- a/src/Thermal/HeatTransfer/sensors.jl
+++ b/src/Thermal/HeatTransfer/sensors.jl
@@ -9,8 +9,8 @@ lags are associated with this sensor model.
 
 # Connectors:
 
-  - `port`: [HeatPort](@ref) Thermal port from which sensor information shall be measured
-  - `T`: [RealOutput](@ref) [K] Absolute temperature of port
+  - `port`: [`HeatPort`](@ref) Thermal port from which sensor information shall be measured
+  - `T`: [`RealOutput`](@ref) [K] Absolute temperature of port
 """
 @component function TemperatureSensor(; name)
     pars = @parameters begin
@@ -42,9 +42,9 @@ output signal in kelvin.
 
 # Connectors:
 
-  - `port_a`: [HeatPort](@ref) Thermal port from which sensor information shall be measured
-  - `port_b`: [HeatPort](@ref) Thermal port from which sensor information shall be measured
-  - `T`: [RealOutput](@ref) [K] Relative temperature `a.T - b.T`
+  - `port_a`: [`HeatPort`](@ref) Thermal port from which sensor information shall be measured
+  - `port_b`: [`HeatPort`](@ref) Thermal port from which sensor information shall be measured
+  - `T`: [`RealOutput`](@ref) [K] Relative temperature `a.T - b.T`
 """
 @component function RelativeTemperatureSensor(; name)
     pars = @parameters begin
@@ -80,9 +80,9 @@ The output signal is positive, if the heat flows from `port_a` to `port_b`.
 
 # Connectors:
 
-  - `port_a`: [HeatPort](@ref) Thermal port from which sensor information shall be measured
-  - `port_b`: [HeatPort](@ref) Thermal port from which sensor information shall be measured
-  - `Q_flow`: [RealOutput](@ref) [W] Heat flow from `port_a` to `port_b` 
+  - `port_a`: [`HeatPort`](@ref) Thermal port from which sensor information shall be measured
+  - `port_b`: [`HeatPort`](@ref) Thermal port from which sensor information shall be measured
+  - `Q_flow`: [`RealOutput`](@ref) [W] Heat flow from `port_a` to `port_b`
 """
 @component function HeatFlowSensor(; name)
     pars = @parameters begin


### PR DESCRIPTION
## Summary

Render cross-references to Julia bindings with Documenter's binding-reference syntax in the component docstrings. Documenter 1.18 tightened cross-reference handling, so the prior header-style links now produce 108 strict documentation errors when reused across the API pages.

> Ignore this PR until reviewed by @ChrisRackauckas.

## Root cause

The affected docstrings used forms such as `[Flange](@ref)`. That syntax asks Documenter to resolve a page-local header or anchor named `Flange`; these links target Julia bindings and therefore require backticked link text: ``[`Flange`](@ref)``. The source contains 65 affected links, which expand to 108 errors because several docstrings appear on more than one rendered API page.

The hosted documentation job was last green with Documenter 1.17 and became red after resolving Documenter 1.18. The stricter resolver exposed malformed existing links; this change corrects the source markup rather than constraining Documenter.

## Failing before

On clean `main` at `c873e68232f5a524a0ee727c87ad52835d1c52cf`, the full documentation build on Julia 1.11 exited 1 before rendering:

```text
$ julia +1.11 --project=docs --startup-file=no docs/make.jl
...
┌ Error: Cannot resolve @ref for md"[OnePort](@ref)" in docs/src/API/domain_reference.md.
...
ERROR: LoadError: `makedocs` encountered an error [:cross_references] -- terminating build before rendering.

$ rg -c 'Cannot resolve @ref' .validation/docs-before.log
108
```

The 108 failures were `Flange` (51), `RealOutput` (14), `OnePort` (13), `HeatPort` (12), `RealInput` (8), `Support` (4), and two each for `VoltageSensor`, `Pin`, and `CurrentSensor`.

## Passing after

The identical full build with these binding links corrected exited 0 and reached rendering:

```text
$ julia +1.11 --project=docs --startup-file=no docs/make.jl
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="2.29.7"` for inventory from ../Project.toml
```

It emitted only the pre-existing HTML-size warnings and the expected local deployment-skip warning.

## Verification

```text
$ GROUP=QA julia +release --project=. --startup-file=no -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   20     20  11m00.8s
Testing ModelingToolkitStandardLibrary tests passed
```

The first Core invocation used `timeout 3600` and expired in `thermal.jl` after 533
passing assertions and three pre-existing broken assertions. It reported no test failure;
the complete warm-cache rerun below used a three-hour shell budget:

```text
$ GROUP=Core timeout 10800 julia +release --project=. --startup-file=no -e 'using Pkg; Pkg.test()'
Core test files | 590 pass, 3 pre-existing broken, 593 total
Testing ModelingToolkitStandardLibrary tests passed

$ julia +release --project=../.tmp/runic-env --startup-file=no -m Runic --check --diff <eight changed files>
# exit 0

$ typos <eight changed files>
# exit 0

$ git diff --check
# exit 0
```

GPU and downstream test groups were not run locally. The change is limited to existing docstring link markup.

## Links

- Last green documentation run (Documenter 1.17.0): https://github.com/SciML/ModelingToolkitStandardLibrary.jl/actions/runs/32947148972
- First cross-reference failure (Documenter 1.18.0): https://github.com/SciML/ModelingToolkitStandardLibrary.jl/actions/runs/33439641598
- Failing hosted documentation run: https://github.com/SciML/ModelingToolkitStandardLibrary.jl/actions/runs/33617618326

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d).
