### PR TITLE
Release ModelingToolkitStandardLibrary 2.29.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkitStandardLibrary"
 uuid = "16a59e39-deab-5bd0-87e4-056b12336739"
-version = "2.29.7"
+version = "2.29.8"
 authors = ["Chris Rackauckas and Julia Computing"]
 
 [deps]


### PR DESCRIPTION
Bumps `ModelingToolkitStandardLibrary` 2.29.7 -> 2.29.8 (patch).

Source files changed since 2.29.7:
- `src/Electrical/Analog/ideal_components.jl`
- `src/Electrical/Analog/sensors.jl`
- `src/Electrical/Analog/sources.jl`
- `src/Mechanical/Rotational/components.jl`
- `src/Mechanical/Rotational/sensors.jl`
- `src/Mechanical/Rotational/sources.jl`
- `src/Mechanical/Rotational/utils.jl`
- `src/Thermal/HeatTransfer/sensors.jl`

Commits:
- Drop stale [compat] majors older than one year (#505)
- build(deps): update DataInterpolations requirement from 6.4, 7, 8, 9.0 to 6.4, 7, 8, 9.0, 10.1 (#506)
- Support DataInterpolations v10.1 (#507)
- Fix Documenter binding references (#509)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
