### PR TITLE
Require Symbolics 7.39.2 (32-bit hash/hasha_seed)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,7 +39,7 @@ SciMLStructures = "1.7.0"
 SciMLTesting = "2.4"
 SymbolicIndexingInterface = "0.3.39"
 SymbolicUtils = "4.38.1"
-Symbolics = "7.4.1"
+Symbolics = "7.39.2"
 Test = "1"
 julia = "1.10"
 


### PR DESCRIPTION
## Summary
- Bump Symbolics lower bound to **7.39.2**, which requires SymbolicUtils 4.46.4 (`Base.hasha_seed % UInt`) and includes the Differential hash fix.
- Unblocks x86 CI once General registers 7.39.2.

## Test plan
- [ ] CI green after Symbolics 7.39.2 is resolvable

Made with [Cursor](https://cursor.com)